### PR TITLE
Fix the default value of sameSite cookie.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --no-plugins"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:

--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -100,7 +100,7 @@ class SwooleEmitter implements EmitterInterface
     private function emitCookies(ResponseInterface $response) : void
     {
         foreach (SetCookies::fromResponse($response)->getAll() as $cookie) {
-            $sameSite = $cookie->getSameSite() ? substr($cookie->getSameSite()->asString(), 9) : null;
+            $sameSite = $cookie->getSameSite() ? substr($cookie->getSameSite()->asString(), 9) : '';
 
             $this->swooleResponse->cookie(
                 $cookie->getName(),

--- a/test/SwooleEmitterTest.php
+++ b/test/SwooleEmitterTest.php
@@ -94,13 +94,13 @@ class SwooleEmitterTest extends TestCase
             ->header('Set-Cookie', Argument::any())
             ->shouldNotBeCalled();
         $this->swooleResponse
-            ->cookie('foo', 'bar', 0, '/', '', false, false, null)
+            ->cookie('foo', 'bar', 0, '/', '', false, false, '')
             ->shouldHaveBeenCalled();
         $this->swooleResponse
-            ->cookie('bar', 'baz', 0, '/', '', false, false, null)
+            ->cookie('bar', 'baz', 0, '/', '', false, false, '')
             ->shouldHaveBeenCalled();
         $this->swooleResponse
-            ->cookie('baz', 'qux', 1623233894, '/', 'somecompany.co.uk', true, true, null)
+            ->cookie('baz', 'qux', 1623233894, '/', 'somecompany.co.uk', true, true, '')
             ->shouldHaveBeenCalled();
 
         // SameSite cookies


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Several people reported the error:

```
Swoole\Http\Response::cookie() expects parameter 8 to be string, null given
```

The under layer type of sameSite in Swoole is string. This PR fixes this issue.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
