### PR TITLE
Fix remote address resolution when the app is served behind a reverse proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#10](https://github.com/mezzio/mezzio-swoole/pull/10) improves how client IP addresses are detected when printing access logs, by taking into consideration `x-real-ip`, `client-ip` and `x-forwarded-for` headers, in that order.
 
 ## 2.6.3 - 2020-04-17
 

--- a/src/Log/AccessLogDataMap.php
+++ b/src/Log/AccessLogDataMap.php
@@ -14,7 +14,6 @@ use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
 use Psr\Http\Message\ResponseInterface as PsrResponse;
 use Swoole\Http\Request as SwooleHttpRequest;
 
-use function array_reduce;
 use function filter_var;
 use function function_exists;
 use function getcwd;
@@ -95,12 +94,15 @@ class AccessLogDataMap
      */
     public function getClientIp() : string
     {
-        $headers = ['x-forwarded-for', 'client-ip', 'x-real-ip'];
-        $headerValue = array_reduce($headers, function (?string $default, string $header) {
-            return $this->request->header[$header] ?? $default;
-        });
+        $headers = ['x-real-ip', 'client-ip', 'x-forwarded-for'];
 
-        return $headerValue ?? $this->getServerParamIp('REMOTE_ADDR');
+        foreach ($headers as $header) {
+            if (isset($this->request->header[$header])) {
+                return $this->request->header[$header];
+            }
+        }
+
+        return $this->getServerParamIp('REMOTE_ADDR');
     }
 
     /**

--- a/test/Log/AccessLogDataMapTest.php
+++ b/test/Log/AccessLogDataMapTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole\Log;
+
+use Mezzio\Swoole\Log\AccessLogDataMap;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Swoole\Http\Request as SwooleHttpRequest;
+
+class AccessLogDataMapTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->request = $this->prophesize(SwooleHttpRequest::class)->reveal();
+        $this->response = $this->prophesize(ResponseInterface::class)->reveal();
+    }
+
+    public function provideServer() : iterable
+    {
+        yield 'no address' => [[], [], '-'];
+        yield 'x-real-ip' => [[
+            'x-real-ip' => '1.1.1.1',
+            'client-ip' => '2.2.2.2',
+            'x-forwarded-for' => '3.3.3.3',
+        ], ['remote_addr' => '4.4.4.4'], '1.1.1.1'];
+        yield 'client-ip' => [[
+            'client-ip' => '2.2.2.2',
+            'x-forwarded-for' => '3.3.3.3',
+        ], ['remote_addr' => '4.4.4.4'], '2.2.2.2'];
+        yield 'x-forwarded-for' => [['x-forwarded-for' => '3.3.3.3'], ['remote_addr' => '4.4.4.4'], '3.3.3.3'];
+        yield 'remote-addr' => [[], ['remote_addr' => '4.4.4.4'], '4.4.4.4'];
+    }
+
+    /**
+     * @dataProvider provideServer
+     */
+    public function testClietnIpIsProperlyResolved(array $headers, array $server, string $expectedIp)
+    {
+        $this->request->server = $server;
+        $this->request->header = $headers;
+        $map = AccessLogDataMap::createWithPsrResponse($this->request, $this->response, false);
+
+        $this->assertEquals($expectedIp, $map->getClientIp());
+    }
+}


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This improves how the client IP address is detected when using the `%h` and/or `%a` modifiers for access logs.

Now also the `x-real-ip`, `client-ip` and `x-forwarded-for` headers are taken into consideration, in that order, in case the app is being served behind a load balancer, reverse proxy or CDN.

This closes #9 