### PR TITLE
Ensure InotifyFileWatcher has a registered service

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -77,6 +77,9 @@ class ConfigProvider
                 SwooleHttpServer::class                => HttpServerFactory::class,
                 Reloader::class                        => ReloaderFactory::class,
             ],
+            'invokables' => [
+                InotifyFileWatcher::class => InotifyFileWatcher::class,
+            ],
             'aliases' => [
                 RequestHandlerRunner::class           => SwooleRequestHandlerRunner::class,
                 StaticResourceHandlerInterface::class => StaticResourceHandler::class,

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace MezzioTest\Swoole;
 
 use Mezzio\Swoole\ConfigProvider;
+use Mezzio\Swoole\HotCodeReload\FileWatcher\InotifyFileWatcher;
 use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
@@ -34,5 +35,18 @@ class ConfigProviderTest extends TestCase
     {
         $this->assertArrayHasKey('dependencies', $config);
         $this->assertIsArray($config['dependencies']);
+        return $config['dependencies'];
+    }
+
+    /**
+     * @depends testReturnedArrayContainsDependencies
+     * @see https://github.com/mezzio/mezzio-swoole/issues/11
+     */
+    public function testEnsureInotifyFileWatcherIsRegistered(array $dependencies): void
+    {
+        $this->assertArrayHasKey('invokables', $dependencies);
+        $this->assertIsArray($dependencies['invokables']);
+        $this->assertArrayHasKey(InotifyFileWatcher::class, $dependencies['invokables']);
+        $this->assertSame(InotifyFileWatcher::class, $dependencies['invokables'][InotifyFileWatcher::class]);
     }
 }


### PR DESCRIPTION
Per #11, while we define an alias for `FileWatcherInterface` and assign it to `InotifyFileWatcher`, the latter did not have a registered service, which caused hot code reloading to fail.

Fixes #11