### PR TITLE
Adds swoole/ide-helper as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "filp/whoops": "^2.1",
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-servicemanager": "^3.3",
-        "phpunit/phpunit": "^8.5.2"
+        "phpunit/phpunit": "^8.5.2",
+        "swoole/ide-helper": "^4.5"
     },
     "conflict": {
         "phpspec/prophecy": "<1.10.2"


### PR DESCRIPTION
The swoole/ide-helper provides aliases for Swoole classes, functions, and constants, ensuring that IDEs are able to autocomplete them.

This patch does not require a new release, or release notes.

Fixes #12