### PR TITLE
Fix SwooleStream is cutting down last byte(character)

### DIFF
--- a/src/SwooleStream.php
+++ b/src/SwooleStream.php
@@ -76,7 +76,7 @@ final class SwooleStream implements StreamInterface
         $index = $this->index;
 
         // Set the internal index to the end of the string
-        $this->index = $size - 1;
+        $this->index = $size;
 
         if ($index) {
             // Per PSR-7 spec, if we have seeked or read to a given position in
@@ -123,7 +123,7 @@ final class SwooleStream implements StreamInterface
      */
     public function eof()
     {
-        return $this->index >= $this->getSize() - 1;
+        return $this->index >= $this->getSize();
     }
 
     /**
@@ -145,7 +145,7 @@ final class SwooleStream implements StreamInterface
         // Reset index based on legnth; should not be > EOF position.
         $size = $this->getSize();
         $this->index = $this->index + $length >= $size
-            ? $size - 1
+            ? $size
             : $this->index + $length;
 
         return $result;
@@ -188,7 +188,7 @@ final class SwooleStream implements StreamInterface
                         'Offset must be a negative number to be under the content size when using SEEK_END'
                     );
                 }
-                $this->index = ($size - 1) + $offset;
+                $this->index = $size + $offset;
                 break;
             default:
                 throw new InvalidArgumentException(

--- a/test/SwooleStreamTest.php
+++ b/test/SwooleStreamTest.php
@@ -40,6 +40,17 @@ class SwooleStreamTest extends TestCase
         $this->stream = new SwooleStream($this->request->reveal());
     }
 
+    public function testEofWhenOneCharacterLeftCase(): void
+    {
+        $len = strlen(self::DEFAULT_CONTENT);
+
+        $this->assertEquals('This is a test', $this->stream->read($len - 1));
+        $this->assertFalse($this->stream->eof());
+
+        $this->assertEquals('!', $this->stream->read(1));
+        $this->assertTrue($this->stream->eof());
+    }
+
     public function testGetContentsWithNoRawContent()
     {
         $request = $this->prophesize(SwooleHttpRequest::class);
@@ -117,13 +128,6 @@ class SwooleStreamTest extends TestCase
         }
     }
 
-    public function testEofIsSizeMinusOne()
-    {
-        $this->assertFalse($this->stream->eof());
-        $this->stream->seek($this->stream->getSize() - 1);
-        $this->assertTrue($this->stream->eof());
-    }
-
     public function testIsReadableReturnsTrue()
     {
         $this->assertTrue($this->stream->isReadable());
@@ -156,7 +160,7 @@ class SwooleStreamTest extends TestCase
         $this->stream->seek(1, SEEK_CUR);
         $this->assertEquals(5, $this->stream->tell());
         $this->stream->seek(-1, SEEK_END);
-        $this->assertEquals(strlen(self::DEFAULT_CONTENT) - 2, $this->stream->tell());
+        $this->assertEquals(strlen(self::DEFAULT_CONTENT) - 1, $this->stream->tell());
     }
 
     public function testSeekSetRaisesExceptionIfPositionOverflows()


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Fixes issue https://github.com/mezzio/mezzio-swoole/issues/15
