### PR TITLE
Add support for URI mapped document roots

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -17,6 +17,9 @@ use Mezzio\Swoole\HotCodeReload\Reloader;
 use Mezzio\Swoole\HotCodeReload\ReloaderFactory;
 use Psr\Http\Message\ServerRequestInterface;
 use Swoole\Http\Server as SwooleHttpServer;
+use StaticResourceHandler\{
+    FileLocationRepository, FileLocationRepositoryFactory, FileLocationRepositoryInterface
+};
 
 use function extension_loaded;
 
@@ -76,14 +79,16 @@ class ConfigProvider
                 StaticResourceHandler::class           => StaticResourceHandlerFactory::class,
                 SwooleHttpServer::class                => HttpServerFactory::class,
                 Reloader::class                        => ReloaderFactory::class,
+                FileLocationRepository::class          => FileLocationRepositoryFactory::class,
             ],
             'invokables' => [
                 InotifyFileWatcher::class => InotifyFileWatcher::class,
             ],
             'aliases' => [
-                RequestHandlerRunner::class           => SwooleRequestHandlerRunner::class,
-                StaticResourceHandlerInterface::class => StaticResourceHandler::class,
-                FileWatcherInterface::class           => InotifyFileWatcher::class,
+                RequestHandlerRunner::class            => SwooleRequestHandlerRunner::class,
+                StaticResourceHandlerInterface::class  => StaticResourceHandler::class,
+                FileWatcherInterface::class            => InotifyFileWatcher::class,
+                FileLocationRepositoryInterface::class => FileLocationRepository::class,
 
                 // Legacy Zend Framework aliases
                 \Zend\Expressive\Swoole\Command\ReloadCommand::class => Command\ReloadCommand::class,

--- a/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
+++ b/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
@@ -12,7 +12,6 @@ namespace Mezzio\Swoole\StaticResourceHandler;
 
 use Swoole\Http\Request;
 
-use function file_exists;
 use function pathinfo;
 
 use const PATHINFO_EXTENSION;
@@ -145,10 +144,6 @@ class ContentTypeFilterMiddleware implements MiddlewareInterface
     {
         $type = pathinfo($fileName, PATHINFO_EXTENSION);
         if (! isset($this->typeMap[$type])) {
-            return false;
-        }
-
-        if (! file_exists($fileName)) {
             return false;
         }
 

--- a/src/StaticResourceHandler/FileLocationRepository.php
+++ b/src/StaticResourceHandler/FileLocationRepository.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Swoole\StaticResourceHandler;
+
+use InvalidArgumentException;
+
+class FileLocationRepository implements FileLocationRepositoryInterface {
+    /**
+     * @var array
+     * Associative array of URI prefixes and directories
+     */
+    private $mappedDocRoots = [];
+
+    /**
+     * Initialize repository with default mapped document roots
+     */
+    public function __construct(array $defaultMappedDocRoots) 
+    {
+        foreach($defaultMappedDocRoots as $prefix => $directories) {
+            foreach($directories as $directory) {
+                $this->addMappedDocumentRoot($prefix, $directory);
+            }
+        }
+    }
+
+    /**
+     * Add the specified directory to list of mapped directories
+     */
+    public function addMappedDocumentRoot(string $prefix, string $directory): void 
+    {
+        $valPrefix =$this->validatePrefix($prefix);
+        $valDirectory = $this->validateDirectory($directory, $valPrefix);
+
+        if(array_key_exists($valPrefix, $this->mappedDocRoots)) {
+            $dirs = &$this->mappedDocRoots[$valPrefix];
+            if(! in_array($valDirectory, $dirs)) {
+                $dirs[] = $valDirectory;
+            }
+        } else {
+            $this->mappedDocRoots[$valPrefix] = [$valDirectory];
+        }
+    }
+
+    /**
+     * Validate prefix, ensuring it is non-empty and starts and ends with a slash
+     */
+    private function validatePrefix(string $prefix): string 
+    {
+        if(empty($prefix)) {
+            // For the default prefix, set it to a slash to get matching to work
+            $prefix = '/';
+        } else {
+            if($prefix[0] != '/') $prefix = "/$prefix";
+            if($prefix[-1] != '/') $prefix .= '/';
+        }
+        return $prefix;
+    }
+
+    /**
+     * Validate directory, ensuring it exists and 
+     */
+    private function validateDirectory(string $directory, string $prefix): string 
+    {
+        if(! is_dir($directory)) {
+            throw new InvalidArgumentException(sprintf(
+                'The document root for "%s", "%s", does not exist; please check your configuration.',
+                empty($prefix) ? "(Default)" : $prefix, $directory
+            ));            
+        }
+        if($directory[-1] != '/') $directory .= '/';
+        return $directory;
+    }
+
+    /**
+     * Return the mapped document roots
+     */
+    public function listMappedDocumentRoots(): array 
+    {
+        return $this->mappedDocRoots;
+    }
+
+    /**
+     * Searches for the specified file in mapped document root
+     * directories; returns the location if found, or null if not
+     */
+    public function findFile(string $filename): ?string 
+    {
+        foreach($this->mappedDocRoots as $prefix => $directories) {
+            foreach($directories as $directory) {
+                if(stripos($filename, $prefix) == 0) {
+                    $mappedFileName = $directory . substr($filename, strlen($prefix));
+                    if(file_exists($mappedFileName)) {
+                        return $mappedFileName;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/StaticResourceHandler/FileLocationRepositoryFactory.php
+++ b/src/StaticResourceHandler/FileLocationRepositoryFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Swoole\StaticResourceHandler;
+
+use Psr\Container\ContainerInterface;
+use InvalidArgumentException;
+use function getcwd;
+
+class FileLocationRepositoryFactory 
+{
+    /** 
+     * Create a file location repository, initializing with the static files setting configured by mezzio-swoole 
+     */
+    public function __invoke(ContainerInterface $container) : FileLocationRepository
+    {
+        $docRoots = $container->get('config')['mezzio-swoole']['swoole-http-server']['static-files']['document-root'] 
+            ?? [getcwd() . '/public'];
+        if(! is_array($docRoots)) {
+            // Accomodate if the user defines document-root as a string or array
+            $docRoots = [$docRoots];
+        }
+        return new FileLocationRepository(count($docRoots) > 0 ? ['' => $docRoots] : []);
+    }    
+}

--- a/src/StaticResourceHandler/FileLocationRepositoryInterface.php
+++ b/src/StaticResourceHandler/FileLocationRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Swoole\StaticResourceHandler;
+
+/**
+ * Interface to implement a repository for storing the association
+ * between the start of a URI (prefix) and directory
+ */
+interface FileLocationRepositoryInterface 
+{
+    function addMappedDocumentRoot(string $prefix, string $directory): void;
+    function listMappedDocumentRoots(): array;
+    function findFile(string $filename): ?string;
+}

--- a/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
+++ b/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
@@ -44,19 +44,6 @@ class ContentTypeFilterMiddlewareTest extends TestCase
         $this->assertAttributeSame($typeMap, 'typeMap', $middleware);
     }
 
-    public function testMiddlewareReturnsFailureResponseIfFileNotFound()
-    {
-        $next = static function ($request, $filename) {
-            TestCase::fail('Should not have invoked next middleware');
-        };
-        $middleware = new ContentTypeFilterMiddleware();
-
-        $response = $middleware($this->request, __DIR__ . '/not-a-valid-file.png', $next);
-
-        $this->assertInstanceOf(StaticResourceResponse::class, $response);
-        $this->assertTrue($response->isFailure());
-    }
-
     public function testMiddlewareReturnsFailureResponseIfFileNotAllowedByTypeMap()
     {
         $next = static function ($request, $filename) {

--- a/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
+++ b/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole;
+
+require_once('_MockIsDir.php');
+
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepository;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class FileLocationRepositoryFactoryTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->fileLocRepoFactory = new FileLocationRepositoryFactory();
+    }
+
+    public function testFactoryReturnsFileLocationRepository()
+    {
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->container->reveal());
+        $this->assertInstanceOf(FileLocationRepository::class, $fileLocRepo);
+    }
+
+    public function testFactoryUsesConfiguredDocumentRoot()
+    {
+        $dir = getcwd() . '/public/';
+        $this->container->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' =>  [
+                    'static-files' => [
+                        'document-root' => [$dir]
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->container->reveal());
+        $this->assertEquals(['/' => [$dir]], $fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testFactoryHasNoDefaultsIfEmptyDocumentRoot()
+    {
+        $dir = getcwd() . '/public/';
+        $this->container->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' =>  [
+                    'static-files' => [
+                        'document-root' => []
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->container->reveal());
+        $this->assertEquals([], $fileLocRepo->listMappedDocumentRoots());
+    }    
+
+    public function testFactoryUsesDefaultDocumentRoot()
+    {
+        $dir = getcwd() . '/public/';
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->container->reveal());
+        $this->assertEquals(['/' => [$dir]], $fileLocRepo->listMappedDocumentRoots());
+    }
+}

--- a/test/StaticResourceHandler/FileLocationRepositoryTest.php
+++ b/test/StaticResourceHandler/FileLocationRepositoryTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole;
+
+require_once('_MockIsDir.php');
+
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepository;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class FileLocationRepositoryTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->testDir = __DIR__;
+        $this->testValDir = __DIR__ . '/';
+        $this->fileLocRepo = new FileLocationRepository(['' => [$this->testValDir]]);
+    }
+
+    public function testCanAddNewWithAddMappedRoot()
+    {
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(['/' => [$this->testValDir], '/foo/' => [$this->testValDir]], 
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testCanAppendWithAddMappedRoot()
+    {
+        $dir2 = __DIR__ . '/../';
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $dir2);
+        $this->assertEquals(['/' => [$this->testValDir], '/foo/' => [$this->testValDir, $dir2]], 
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }
+
+
+    public function testNoDupeAddMappedRoot()
+    {
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(['/' => [$this->testValDir], '/foo/' => [$this->testValDir]], 
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }    
+
+    public function testValidatePrefixReturnsSlashOnEmpty()
+    {
+        // validatePrefix called from addMappDocumentRoot
+        $this->fileLocRepo->addMappedDocumentRoot('', '/public');
+        $this->assertEquals(['/' => [$this->testValDir, '/public/']],
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testValidatePrefixPrependsSlash()
+    {
+        // validatePrefix called from addMappDocumentRoot
+        $dir = getcwd() . '/';
+        $this->fileLocRepo->addMappedDocumentRoot('foo/', $this->testDir);
+        $this->assertEquals(['/' => [$this->testValDir], '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testValidatePrefixAppendsSlash()
+    {
+        // validatePrefix called from addMappDocumentRoot
+        $dir = getcwd() . '/';
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(['/' => [$this->testValDir], '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }    
+
+    public function testValidateDirectoryReturnsIfDirectoryExists()
+    {
+        // validateDirectory called from addMappDocumentRoot
+        $dir = getcwd();
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(['/' => [$this->testValDir], '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }        
+
+    public function testValidateDirectoryFaultsIfDirectoryExists()
+    {
+        // validateDirectory called from addMappDocumentRoot
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The document root for "/foo/", "BOGUS", does not exist; please check your configuration.');
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', 'BOGUS');
+    }
+
+    public function testValidatePDirctoryAppendsSlash()
+    {
+        // validatePrefix called from addMappDocumentRoot
+        $dir = getcwd();
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(['/' => [$this->testValDir], '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }    
+
+    public function testListMappedDocumentRoots()
+    {
+        $this->assertEquals(['/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testFindFileExists() 
+    {
+        $dir = realpath(__DIR__ . '/../TestAsset');
+        $full = realpath($dir . '/content.txt');
+        // Add two directories for "test" so we can make sure non-matches are skipped
+        $this->fileLocRepo->addMappedDocumentRoot('/test/', getcwd());
+        $this->fileLocRepo->addMappedDocumentRoot('/test/', $dir);
+        $this->assertEquals($full, $this->fileLocRepo->findFile('/test/content.txt'));
+    }
+
+    public function testFindFileDoesNotExist() 
+    {
+        $this->assertEquals(null, $this->fileLocRepo->findFile('/foo'));
+    }    
+}

--- a/test/StaticResourceHandler/_MockIsDir.php
+++ b/test/StaticResourceHandler/_MockIsDir.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Swoole\StaticResourceHandler;
+/**
+ * Mock is_dir so that it always returns true unless directory is BOGUS
+ */
+function is_dir($dir) {
+    return $dir != 'BOGUS';
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Additional functionality for StaticResourceHandler.  This allows a module which serves templates to include links for assets like JavaScript and CSS files, without having to copy those files to "public" (or any pre-defined document-root folder).  

In my use case, I was writing a module to serve Swagger API documentation from a site running under `mezzio-swoole start`.  Using this new method, I can set up my template's links like:
```html
<script src="/swagger/swagger-ui-bundle.js"> </script>
```

and configure StaticResourceHandler to serve files from the module's template folder when it sees "/swagger" at the start of the URI:

```php
class ConfigProvider
{
    /**
     * Returns the configuration array
     *
     * To add a bit of a structure, each section is defined in a separate
     * method which returns an array with its configuration.
     */
    public function __invoke() : array
    {
        return [
            'mezzio-swoole' => $this->getMezzioSwooleConfig(),
            'dependencies'  => $this->getDependencies(),
            'routes'        => $this->getRoutes(),
            'templates'     => $this->getTemplates(),
        ];
    }

    public function getMezzioSwooleConfig() : array
    {
        return [
            'swoole-http-server' => [
                'static-files' => [
                    'mapped-document-roots' => [
                        'swagger' => __DIR__ . '/../templates/swagger'
                    ]
                ]
            ]
        ];
    }

   // etc.
```

Some implementation notes:

There is a `FileLocationRepository` that stores the relationship between URI prefixes ("/", "swagger") and one or more directories.  This repository is injected into `StaticResourceHandler` instead of the document root directory (`$docRoot`).

Since `FileLocationRepository` checks for the existence of a file when reconciling a URI with registered prefixes, I removed the file_exists check from `ContentTypeFilterMiddleware`

Documentation is in `docs/book/v2/static-resources.md` (look for "Mapped Document Roots")

php-cs, phpunit all pass, and I think I got the --signoff thing right