### PR TITLE
Add Mapped Document Roots functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,28 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Nothing.
 
+## 2.6.7 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 2.6.6 - 2020-06-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,28 +24,6 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Nothing.
 
-## 2.6.7 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
 ## 2.6.6 - 2020-06-17
 
 ### Added

--- a/docs/book/v2/static-resources.md
+++ b/docs/book/v2/static-resources.md
@@ -308,6 +308,88 @@ return [
 ];
 ```
 
+## Mapped Document Roots
+
+The `Mezzio\Swoole\StaticResourceHandler\FileLocationRepository` implements the  `Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryInterface` to maintain an association of URI prefixes with file directories.  A module can designate the URL prefix `/my-module` to refer to files located in its `templates` directory. 
+
+An example use case would be if you have a module that contains a template, and that template relies on assets like JavaScript files, CSS files, etc.  Instead of copying those assets to a public directory configured in `document-root`, you can leave the files in the module, and access them using a defined URI prefix.
+
+To accomplish this:
+
+1. Define what your URI prefix will be (ex. /my-module)
+2. Update your template/s attributes like `href` and `src` to use the prefix (ex. `<script src='/my-module/style.css'></script>`)
+3. In the factory of your handler, or whatever is rendering the template, set up the linkage between the prefix and the directory where your assets are located.
+
+### Mapped Document Roots - Example
+
+Assume you have a module, AwesomeModule, which has a handler called "HomeHandler", which renders the 'home' template.  You designate the prefix, `/awesome-home` for rendering the assets.  The structure of your module looks like this:
+
+```
+AwesomeModule
+├── src
+|   ├── Handler
+|   |   ├── HomeHandler.php
+|   |   ├── HomeHandlerFactory.php
+|   ├── ConfigProvider.php
+├── templates
+│   ├── home
+|   |   ├── home.html
+|   |   ├── style.css
+│   ├── layouts
+```
+
+In your `home.html` template, you can refer to the `style.css` file as follows:
+
+```
+<link href="/awesome-home/style.css" rel="stylesheet" type="text/css">
+```
+
+In your module's ConfigProvider, you can add a configuration setting as follows:
+```php
+    public function __invoke() : array
+    {
+        return [
+            'config' => [
+                'mezzio-swoole' => [
+                    'swoole-http-server' => [
+                        'static-files' => [
+                            'mapped-document-roots' => [
+                                'awseome-home' => __DIR__ . '/../../templates/home'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+```
+
+Alterantively, in the factory of the module, or the handler you create assignment for `/awesome-home` to your modules's `templates/home` directory.  
+This approach could be useful if the directory of the assets isn't know until runtime.
+
+```php
+use Psr\Container\ContainerInterface;
+use Mezzio\Template\TemplateRendererInterface;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryInterface;
+
+class AwesomeHomeHandlerFactory
+{
+    public function __invoke(ContainerInterface $container) : DocumentationViewHandler
+    {
+        // Establish location for the home template assets
+        $repo = $container->get(FileLocationRepositoryInterface::class);
+        $repo->addMappedDocumentRoot('awesome-home', 
+            realpath(__DIR__ . '/../../templates/home'));
+
+        return new AwesomeHomeHandler(
+            $container->get(TemplateRendererInterface::class)
+        );
+    }
+}
+```
+
+When the template renders, the client will request `/awesome-home/style.css`, which the StaticResourceHandler will now retrieve from the `templates/home` folder of the module.
+
 ## Writing Middleware
 
 Static resource middleware must implement

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -15,6 +15,9 @@ use Mezzio\Swoole\HotCodeReload\FileWatcher\InotifyFileWatcher;
 use Mezzio\Swoole\HotCodeReload\FileWatcherInterface;
 use Mezzio\Swoole\HotCodeReload\Reloader;
 use Mezzio\Swoole\HotCodeReload\ReloaderFactory;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepository;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryFactory;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Swoole\Http\Server as SwooleHttpServer;
 
@@ -76,14 +79,16 @@ class ConfigProvider
                 StaticResourceHandler::class           => StaticResourceHandlerFactory::class,
                 SwooleHttpServer::class                => HttpServerFactory::class,
                 Reloader::class                        => ReloaderFactory::class,
+                FileLocationRepository::class          => FileLocationRepositoryFactory::class,
             ],
             'invokables' => [
                 InotifyFileWatcher::class => InotifyFileWatcher::class,
             ],
             'aliases' => [
-                RequestHandlerRunner::class           => SwooleRequestHandlerRunner::class,
-                StaticResourceHandlerInterface::class => StaticResourceHandler::class,
-                FileWatcherInterface::class           => InotifyFileWatcher::class,
+                RequestHandlerRunner::class            => SwooleRequestHandlerRunner::class,
+                StaticResourceHandlerInterface::class  => StaticResourceHandler::class,
+                FileWatcherInterface::class            => InotifyFileWatcher::class,
+                FileLocationRepositoryInterface::class => FileLocationRepository::class,
 
                 // Legacy Zend Framework aliases
                 \Zend\Expressive\Swoole\Command\ReloadCommand::class => Command\ReloadCommand::class,

--- a/src/StaticResourceHandler.php
+++ b/src/StaticResourceHandler.php
@@ -12,18 +12,13 @@ namespace Mezzio\Swoole;
 
 use Swoole\Http\Request as SwooleHttpRequest;
 use Swoole\Http\Response as SwooleHttpResponse;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryInterface;
 
 use function is_callable;
-use function is_dir;
 use function sprintf;
 
 class StaticResourceHandler implements StaticResourceHandlerInterface
 {
-    /**
-     * @var string
-     */
-    private $docRoot;
-
     /**
      * Middleware to execute when serving a static resource.
      *
@@ -32,30 +27,33 @@ class StaticResourceHandler implements StaticResourceHandlerInterface
     private $middleware;
 
     /**
+     * Middleware to execute when serving a static resource.
+     *
+     * @var StaticResourceHandler\FileLocationRepositoryInterface[]
+     */
+    private $fileLocationRepo;
+
+    /**
      * @throws Exception\InvalidStaticResourceMiddlewareException for any
      *     non-callable middleware encountered.
      */
     public function __construct(
-        string $docRoot,
+        FileLocationRepositoryInterface $fileLocationRepo,
         array $middleware = []
     ) {
-        if (! is_dir($docRoot)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'The document root "%s" does not exist; please check your configuration.',
-                $docRoot
-            ));
-        }
         $this->validateMiddleware($middleware);
-
-        $this->docRoot = $docRoot;
         $this->middleware = $middleware;
+        $this->fileLocationRepo = $fileLocationRepo;
     }
 
     public function processStaticResource(
         SwooleHttpRequest $request,
         SwooleHttpResponse $response
     ) : ?StaticResourceHandler\StaticResourceResponse {
-        $filename = $this->docRoot . $request->server['request_uri'];
+        $filename = $this->fileLocationRepo->findFile($request->server['request_uri']);
+        if (! $filename) {
+            return null;
+        }
 
         $middleware = new StaticResourceHandler\MiddlewareQueue($this->middleware);
         $staticResourceResponse = $middleware($request, $filename);

--- a/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
+++ b/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
@@ -12,7 +12,6 @@ namespace Mezzio\Swoole\StaticResourceHandler;
 
 use Swoole\Http\Request;
 
-use function file_exists;
 use function pathinfo;
 
 use const PATHINFO_EXTENSION;
@@ -145,10 +144,6 @@ class ContentTypeFilterMiddleware implements MiddlewareInterface
     {
         $type = pathinfo($fileName, PATHINFO_EXTENSION);
         if (! isset($this->typeMap[$type])) {
-            return false;
-        }
-
-        if (! file_exists($fileName)) {
             return false;
         }
 

--- a/src/StaticResourceHandler/FileLocationRepository.php
+++ b/src/StaticResourceHandler/FileLocationRepository.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Swoole\StaticResourceHandler;
+
+use InvalidArgumentException;
+
+class FileLocationRepository implements FileLocationRepositoryInterface
+{
+    /**
+     * @var array
+     * Associative array of URI prefixes and directories
+     */
+    private $mappedDocRoots = [];
+
+    /**
+     * Initialize repository with default mapped document roots
+     */
+    public function __construct(array $mappedDocRoots)
+    {
+        // Set up any mapped document roots, validating prefixes and directories
+        foreach ($mappedDocRoots as $prefix => $directory) {
+            if (is_array($directory)) {
+                foreach ($directory as $d) {
+                    $this->addMappedDocumentRoot($prefix, $d);
+                }
+            } else {
+                $this->addMappedDocumentRoot($prefix, $directory);
+            }
+        }
+    }
+
+    /**
+     * Add the specified directory to list of mapped directories
+     */
+    public function addMappedDocumentRoot(string $prefix, string $directory): void
+    {
+        $valPrefix = $this->validatePrefix($prefix);
+        $valDirectory = $this->validateDirectory($directory, $valPrefix);
+
+        if (array_key_exists($valPrefix, $this->mappedDocRoots)) {
+            $dirs = &$this->mappedDocRoots[$valPrefix];
+            if (! in_array($valDirectory, $dirs)) {
+                $dirs[] = $valDirectory;
+            }
+        } else {
+            $this->mappedDocRoots[$valPrefix] = [$valDirectory];
+        }
+    }
+
+    /**
+     * Validate prefix, ensuring it is non-empty and starts and ends with a slash
+     */
+    private function validatePrefix(string $prefix): string
+    {
+        if (empty($prefix)) {
+            // For the default prefix, set it to a slash to get matching to work
+            $prefix = '/';
+        } else {
+            if ($prefix[0] != '/') {
+                $prefix = "/$prefix";
+            }
+            if ($prefix[-1] != '/') {
+                $prefix .= '/';
+            }
+        }
+        return $prefix;
+    }
+
+    /**
+     * Validate directory, ensuring it exists and
+     */
+    private function validateDirectory(string $directory, string $prefix): string
+    {
+        if (! is_dir($directory)) {
+            throw new InvalidArgumentException(sprintf(
+                'The document root for "%s", "%s", does not exist; please check your configuration.',
+                empty($prefix) ? "(Default)" : $prefix,
+                $directory
+            ));
+        }
+        if ($directory[-1] != '/') {
+            $directory .= '/';
+        }
+        return $directory;
+    }
+
+    /**
+     * Return the mapped document roots
+     */
+    public function listMappedDocumentRoots(): array
+    {
+        return $this->mappedDocRoots;
+    }
+
+    /**
+     * Searches for the specified file in mapped document root
+     * directories; returns the location if found, or null if not
+     */
+    public function findFile(string $filename): ?string
+    {
+        foreach ($this->mappedDocRoots as $prefix => $directories) {
+            foreach ($directories as $directory) {
+                if (stripos($filename, $prefix) == 0) {
+                    $mappedFileName = $directory . substr($filename, strlen($prefix));
+                    if (file_exists($mappedFileName)) {
+                        return $mappedFileName;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/StaticResourceHandler/FileLocationRepositoryFactory.php
+++ b/src/StaticResourceHandler/FileLocationRepositoryFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Swoole\StaticResourceHandler;
+
+use Psr\Container\ContainerInterface;
+use InvalidArgumentException;
+use function getcwd;
+
+class FileLocationRepositoryFactory
+{
+    /**
+     * Create a file location repository, initializing with the static files setting configured by mezzio-swoole
+     */
+    public function __invoke(ContainerInterface $container) : FileLocationRepository
+    {
+        // Build list of document roots mapped to the default document root directory
+        $configDocRoots = $container->get('config')
+            ['mezzio-swoole']['swoole-http-server']['static-files']['document-root']
+            ?? getcwd() . '/public';
+        $isArray = \is_array($configDocRoots);
+
+        $mappedDocRoots = ($isArray && (count($configDocRoots) > 0))
+            || ((! $isArray) && strlen(strval($configDocRoots)) > 0)
+            ? ['/' => $configDocRoots]
+            : [];
+
+        // Add any configured mapped document roots
+        $configMappedDocRoots = $container->get('config')
+            ['mezzio-swoole']['swoole-http-server']['static-files']['mapped-document-roots']
+            ?? [];
+
+        if (count($configMappedDocRoots) > 0) {
+            $mappedDocRoots = array_merge($mappedDocRoots, $configMappedDocRoots);
+        }
+
+        return new FileLocationRepository($mappedDocRoots);
+    }
+}

--- a/src/StaticResourceHandler/FileLocationRepositoryInterface.php
+++ b/src/StaticResourceHandler/FileLocationRepositoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Swoole\StaticResourceHandler;
+
+/**
+ * Interface to implement a repository for storing the association
+ * between the start of a URI (prefix) and directory
+ */
+interface FileLocationRepositoryInterface
+{
+    public function addMappedDocumentRoot(string $prefix, string $directory): void;
+    public function listMappedDocumentRoots(): array;
+    public function findFile(string $filename): ?string;
+}

--- a/src/StaticResourceHandlerFactory.php
+++ b/src/StaticResourceHandlerFactory.php
@@ -70,9 +70,8 @@ class StaticResourceHandlerFactory
     public function __invoke(ContainerInterface $container) : StaticResourceHandler
     {
         $config = $container->get('config')['mezzio-swoole']['swoole-http-server']['static-files'] ?? [];
-
         return new StaticResourceHandler(
-            $config['document-root'] ?? getcwd() . '/public',
+            $container->get(StaticResourceHandler\FileLocationRepositoryInterface::class),
             $this->configureMiddleware($config)
         );
     }

--- a/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
+++ b/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
@@ -44,19 +44,6 @@ class ContentTypeFilterMiddlewareTest extends TestCase
         $this->assertAttributeSame($typeMap, 'typeMap', $middleware);
     }
 
-    public function testMiddlewareReturnsFailureResponseIfFileNotFound()
-    {
-        $next = static function ($request, $filename) {
-            TestCase::fail('Should not have invoked next middleware');
-        };
-        $middleware = new ContentTypeFilterMiddleware();
-
-        $response = $middleware($this->request, __DIR__ . '/not-a-valid-file.png', $next);
-
-        $this->assertInstanceOf(StaticResourceResponse::class, $response);
-        $this->assertTrue($response->isFailure());
-    }
-
     public function testMiddlewareReturnsFailureResponseIfFileNotAllowedByTypeMap()
     {
         $next = static function ($request, $filename) {

--- a/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
+++ b/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole;
+
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepository;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class FileLocationRepositoryFactoryTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->mockContainer = $this->prophesize(ContainerInterface::class);
+        $this->fileLocRepoFactory = new FileLocationRepositoryFactory();
+        $this->assetDir = __DIR__ . '/../TestAsset';
+    }
+
+    public function testFactoryReturnsFileLocationRepository()
+    {
+        $this->mockContainer->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'document-root' => []
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $this->assertInstanceOf(FileLocationRepository::class, $fileLocRepo);
+    }
+
+    public function testFactoryUsesConfiguredDocumentRootArray()
+    {
+        $this->mockContainer->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'document-root' => [$this->assetDir]
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $this->assertEquals(['/' => [$this->assetDir . '/']], $fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testFactoryUsesConfiguredMappedDocumentRootsArray()
+    {
+        $this->mockContainer->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'document-root' => [],
+                        'mapped-document-roots' => [
+                            'foo' => [$this->assetDir]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $this->assertEquals(['/foo/' => [$this->assetDir . '/']], $fileLocRepo->listMappedDocumentRoots());
+    }
+
+
+    public function testFactoryUsesConfiguredMappedDocumentRootString()
+    {
+        $this->mockContainer->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'document-root' => [],
+                        'mapped-document-roots' => [
+                            'foo' => [$this->assetDir]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->mockContainer->reveal());
+
+        $this->assertEquals(['/foo/' => [$this->assetDir . '/']], $fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testFactoryUsesBothConfiguredRootAndMappedDocumentRootString()
+    {
+        $this->mockContainer->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'document-root' => __DIR__,
+                        'mapped-document-roots' => [
+                            'foo' => [$this->assetDir]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->mockContainer->reveal());
+
+        $this->assertEquals(
+            ['/' => [__DIR__ . '/'], '/foo/' => [$this->assetDir . '/']],
+            $fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+    public function testFactoryUsesConfiguredDocumentRootString()
+    {
+        $this->mockContainer->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'document-root' => $this->assetDir
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->mockContainer->reveal());
+
+        $this->assertEquals(['/' => [$this->assetDir . '/']], $fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testFactoryHasNoDefaultsIfEmptyDocumentRoot()
+    {
+        $this->mockContainer->get('config')->willReturn([
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'document-root' => []
+                    ]
+                ]
+            ]
+        ]);
+        $factory = $this->fileLocRepoFactory;
+        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $this->assertEquals([], $fileLocRepo->listMappedDocumentRoots());
+    }
+
+    public function testFactoryUsesDefaultDocumentRoot()
+    {
+        // Note - we are creating a temporary location to create a public folder,
+        // since mocking is_dir and making phpcs happy at the same time
+        // is problematic
+        $cwd = \getcwd();
+        $seed = time();
+        $tmpDir = \sys_get_temp_dir();
+        $tmpDir1 = $tmpDir . '/' . $seed;
+        $tmpDir2 = $tmpDir1 . '/' . 'public';
+        try {
+            mkdir($tmpDir1);
+            mkdir($tmpDir2);
+            \chdir($tmpDir1);
+            $this->mockContainer->get('config')->willReturn([
+                'mezzio-swoole' => [
+                    'swoole-http-server' => [
+                        'static-files' => [
+                        ]
+                    ]
+                ]
+            ]);
+            $factory = $this->fileLocRepoFactory;
+            $fileLocRepo = $factory($this->mockContainer->reveal());
+            $this->assertEquals(['/' => [$tmpDir2 . '/']], $fileLocRepo->listMappedDocumentRoots());
+        } finally {
+            \rmdir($tmpDir2);
+            \rmdir($tmpDir1);
+            \chdir($cwd);
+        }
+    }
+}

--- a/test/StaticResourceHandler/FileLocationRepositoryTest.php
+++ b/test/StaticResourceHandler/FileLocationRepositoryTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole;
+
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepository;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class FileLocationRepositoryTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->testDir = __DIR__;
+        $this->testValDir = __DIR__ . '/';
+        $this->fileLocRepo = new FileLocationRepository(['/' => $this->testValDir]);
+    }
+
+    public function testCanAddNewWithAddMappedRoot()
+    {
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(
+            ['/' => [$this->testValDir],
+            '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+    public function testCanAppendWithAddMappedRoot()
+    {
+        $dir2 = __DIR__ . '/../';
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $dir2);
+        $this->assertEquals(
+            ['/' => [$this->testValDir],
+            '/foo/' => [$this->testValDir, $dir2]],
+            $this->fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+
+    public function testNoDupeAddMappedRoot()
+    {
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(
+            ['/' => [$this->testValDir],
+            '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+    public function testValidatePrefixReturnsSlashOnEmpty()
+    {
+        // Note - we are creating a temporary location to create a public folder,
+        // since mocking is_dir and making phpcs happy at the same time
+        // is problematic
+        $cwd = \getcwd();
+        $seed = time();
+        $tmpDir = \sys_get_temp_dir();
+        $tmpDir1 = $tmpDir . '/' . $seed;
+        $tmpDir2 = $tmpDir1 . '/' . 'public';
+        try {
+            mkdir($tmpDir1);
+            mkdir($tmpDir2);
+            // validatePrefix called from addMappDocumentRoot
+            $this->fileLocRepo->addMappedDocumentRoot('', $tmpDir2);
+            $this->assertEquals(
+                ['/' => [$this->testValDir, $tmpDir2 . '/']],
+                $this->fileLocRepo->listMappedDocumentRoots()
+            );
+        } finally {
+            \rmdir($tmpDir2);
+            \rmdir($tmpDir1);
+            \chdir($cwd);
+        }
+    }
+
+    public function testValidatePrefixPrependsSlash()
+    {
+        // validatePrefix called from addMappDocumentRoot
+        $dir = getcwd() . '/';
+        $this->fileLocRepo->addMappedDocumentRoot('foo/', $this->testDir);
+        $this->assertEquals(
+            ['/' => [$this->testValDir],
+            '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+    public function testValidatePrefixAppendsSlash()
+    {
+        // validatePrefix called from addMappDocumentRoot
+        $dir = getcwd() . '/';
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(
+            ['/' => [$this->testValDir],
+            '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+    public function testValidateDirectoryReturnsIfDirectoryExists()
+    {
+        // validateDirectory called from addMappDocumentRoot
+        $dir = getcwd();
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(
+            ['/' => [$this->testValDir],
+            '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+    public function testValidateDirectoryFaultsIfDirectoryExists()
+    {
+        // validateDirectory called from addMappDocumentRoot
+        $this->expectException(\Exception::class);
+        $msg = 'The document root for "/foo/", "BOGUS", does not exist; please check your configuration.';
+        $this->expectExceptionMessage($msg);
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', 'BOGUS');
+    }
+
+    public function testValidatePDirctoryAppendsSlash()
+    {
+        // validatePrefix called from addMappDocumentRoot
+        $dir = getcwd();
+        $this->fileLocRepo->addMappedDocumentRoot('/foo', $this->testDir);
+        $this->assertEquals(
+            ['/' => [$this->testValDir], '/foo/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+    public function testListMappedDocumentRoots()
+    {
+        $this->assertEquals(
+            ['/' => [$this->testValDir]],
+            $this->fileLocRepo->listMappedDocumentRoots()
+        );
+    }
+
+    public function testFindFileExists()
+    {
+        $dir = realpath(__DIR__ . '/../TestAsset');
+        $full = realpath($dir . '/content.txt');
+        // Add two directories for "test" so we can make sure non-matches are skipped
+        $this->fileLocRepo->addMappedDocumentRoot('/test/', getcwd());
+        $this->fileLocRepo->addMappedDocumentRoot('/test/', $dir);
+        $this->assertEquals($full, $this->fileLocRepo->findFile('/test/content.txt'));
+    }
+
+    public function testFindFileDoesNotExist()
+    {
+        $this->assertEquals(null, $this->fileLocRepo->findFile('/foo'));
+    }
+}

--- a/test/StaticResourceHandlerTest.php
+++ b/test/StaticResourceHandlerTest.php
@@ -14,6 +14,7 @@ use Mezzio\Swoole\Exception;
 use Mezzio\Swoole\StaticResourceHandler;
 use Mezzio\Swoole\StaticResourceHandler\MiddlewareInterface;
 use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 use Swoole\Http\Request as SwooleHttpRequest;
 use Swoole\Http\Response as SwooleHttpResponse;
@@ -22,7 +23,9 @@ class StaticResourceHandlerTest extends TestCase
 {
     protected function setUp() : void
     {
-        $this->docRoot = __DIR__ . '/TestAsset';
+        $this->uri = '/image.png';
+        $this->fullPath = __DIR__ . '/TestAsset' . $this->uri;
+        $this->fileLocRepo = $this->prophesize(FileLocationRepositoryInterface::class);
         $this->request = $this->prophesize(SwooleHttpRequest::class)->reveal();
         $this->response = $this->prophesize(SwooleHttpResponse::class)->reveal();
     }
@@ -30,13 +33,13 @@ class StaticResourceHandlerTest extends TestCase
     public function testConstructorRaisesExceptionForInvalidMiddlewareValue()
     {
         $this->expectException(Exception\InvalidStaticResourceMiddlewareException::class);
-        new StaticResourceHandler($this->docRoot, [$this]);
+        new StaticResourceHandler($this->fileLocRepo->reveal(), [$this]);
     }
 
     public function testProcessStaticResourceReturnsNullIfMiddlewareReturnsFailureResponse()
     {
         $this->request->server = [
-            'request_uri' => '/image.png',
+            'request_uri' => $this->uri,
         ];
 
         $middleware = new class() implements MiddlewareInterface {
@@ -51,21 +54,19 @@ class StaticResourceHandlerTest extends TestCase
             }
         };
 
-        $handler = new StaticResourceHandler($this->docRoot, [$middleware]);
+        $handler = new StaticResourceHandler($this->fileLocRepo->reveal(), [$middleware]);
         $this->assertNull($handler->processStaticResource($this->request, $this->response));
     }
 
     public function testProcessStaticResourceReturnsStaticResponseWhenSuccessful()
     {
-        $filename = $this->docRoot . '/image.png';
-
         $this->request->server = [
-            'request_uri' => '/image.png',
+            'request_uri' => $this->uri,
         ];
 
         $expectedResponse = $this->prophesize(StaticResourceResponse::class);
         $expectedResponse->isFailure()->willReturn(false);
-        $expectedResponse->sendSwooleResponse($this->response, $filename)->shouldBeCalled();
+        $expectedResponse->sendSwooleResponse($this->response, $this->fullPath)->shouldBeCalled();
 
         $middleware = new class($expectedResponse->reveal()) implements MiddlewareInterface {
             private $response;
@@ -84,10 +85,59 @@ class StaticResourceHandlerTest extends TestCase
             }
         };
 
-        $handler = new StaticResourceHandler($this->docRoot, [$middleware]);
+        $this->fileLocRepo->findFile($this->uri)->willReturn($this->fullPath);
+        $handler = new StaticResourceHandler($this->fileLocRepo->reveal(), [$middleware]);
 
         $this->assertSame(
             $expectedResponse->reveal(),
+            $handler->processStaticResource($this->request, $this->response)
+        );
+    }
+
+    public function testProcessStaticResourceReturnsNullWhenMiddlewareFails()
+    {
+        $this->request->server = [
+            'request_uri' => $this->uri,
+        ];
+
+        $expectedResponse = $this->prophesize(StaticResourceResponse::class);
+        $expectedResponse->isFailure()->willReturn(true);
+
+        $middleware = new class($expectedResponse->reveal()) implements MiddlewareInterface {
+            private $response;
+
+            public function __construct(StaticResourceResponse $response)
+            {
+                $this->response = $response;
+            }
+
+            public function __invoke(
+                SwooleHttpRequest $request,
+                string $filename,
+                callable $next
+            ) : StaticResourceResponse {
+                return $this->response;
+            }
+        };
+
+        $this->fileLocRepo->findFile($this->uri)->willReturn($this->fullPath);
+        $handler = new StaticResourceHandler($this->fileLocRepo->reveal(), [$middleware]);
+        $this->assertSame(
+            null,
+            $handler->processStaticResource($this->request, $this->response)
+        );
+    }
+
+    public function testProcessStaticResourceReturnsNullOnInvalidFile()
+    {
+        $this->request->server = [
+            'request_uri' => '/BOGUS',
+        ];
+
+        $handler = new StaticResourceHandler($this->fileLocRepo->reveal(), []);
+
+        $this->assertSame(
+            null,
             $handler->processStaticResource($this->request, $this->response)
         );
     }


### PR DESCRIPTION
Signed-off-by: Jason Terando <jason.t@digitalroominc.com>

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Additional functionality for StaticResourceHandler.  This allows a module which serves templates to include links for assets like JavaScript and CSS files, without having to copy those files to "public" (or any pre-defined document-root folder).  

In my use case, I was writing a module to serve Swagger API documentation from a site running under `mezzio-swoole start`.  Using this new method, I can set up my template's links like:
```html
<script src="/swagger/swagger-ui-bundle.js"> </script>
```

and configure StaticResourceHandler to serve files from the module's template folder when it sees "/swagger" at the start of the URI:

```php
class ConfigProvider
{
    /**
     * Returns the configuration array
     *
     * To add a bit of a structure, each section is defined in a separate
     * method which returns an array with its configuration.
     */
    public function __invoke() : array
    {
        return [
            'mezzio-swoole' => $this->getMezzioSwooleConfig(),
            'dependencies'  => $this->getDependencies(),
            'routes'        => $this->getRoutes(),
            'templates'     => $this->getTemplates(),
        ];
    }

    public function getMezzioSwooleConfig() : array
    {
        return [
            'swoole-http-server' => [
                'static-files' => [
                    'mapped-document-roots' => [
                        'swagger' => __DIR__ . '/../templates/swagger'
                    ]
                ]
            ]
        ];
    }

   // etc.
```

Some implementation notes:

There is a `FileLocationRepository` that stores the relationship between URI prefixes ("/", "swagger") and one or more directories.  This repository is injected into `StaticResourceHandler` instead of the document root directory (`$docRoot`).

Since `FileLocationRepository` checks for the existence of a file when reconciling a URI with registered prefixes, I removed the file_exists check from `ContentTypeFilterMiddleware`

Documentation is in `docs/book/v2/static-resources.md` (look for "Mapped Document Roots")
