### PR TITLE
Switch to composer/package-versions-deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     "require": {
         "php": "^7.2",
         "ext-swoole": "^4.4.6",
+        "composer/package-versions-deprecated": "^1.11",
         "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-diactoros": "^1.8 || ^2.0",
         "laminas/laminas-httphandlerrunner": "^1.0.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio": "^3.0.2",
-        "ocramius/package-versions": "^1.3",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-message-implementation": "^1.0",


### PR DESCRIPTION
Simplifies the version constraints we can use, and prepares us for Composer v2 releases.

Fixes #17
