### PR TITLE
Remove PHPUnit warnings

### DIFF
--- a/test/AttributeAssertionTrait.php
+++ b/test/AttributeAssertionTrait.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-swoole/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole;
+
+use PHPUnit\Framework\Assert;
+use ReflectionProperty;
+
+/**
+ * Shim to allow attribute assertions with PHPUnit 9/10+
+ *
+ * Many properties do not have easy ways for us to test, so using reflection
+ * still makes sense. This trait reproduces the functionality from previous
+ * PHPUnit versions, keeping compatibility.
+ */
+trait AttributeAssertionTrait
+{
+    /**
+     * @param object $instance Instance composing attribute to test
+     */
+    public static function assertAttributeEmpty(string $attributeName, $instance, string $message = ''): void
+    {
+        $r = new ReflectionProperty($instance, $attributeName);
+        $r->setAccessible(true);
+        Assert::assertEmpty($r->getValue($instance), $message);
+    }
+
+    /**
+     * @param mixed  $expected Expected value
+     * @param object $instance Instance composing attribute to test
+     */
+    public static function assertAttributeEquals(
+        $expected,
+        string $attributeName,
+        $instance,
+        string $message = '',
+        float $delta = 0,
+        int $maxDepth = 10,
+        bool $canonicalize = false,
+        bool $ignoreCase = false
+    ): void {
+        $r = new ReflectionProperty($instance, $attributeName);
+        $r->setAccessible(true);
+        Assert::assertEquals($expected, $r->getValue($instance), $message);
+    }
+
+    /**
+     * @param mixed  $expected Expected type
+     * @param object $instance Instance composing attribute to test
+     */
+    public static function assertAttributeInstanceOf(
+        $expected,
+        string $attributeName,
+        $instance,
+        string $message = ''
+    ): void {
+        $r = new ReflectionProperty($instance, $attributeName);
+        $r->setAccessible(true);
+        Assert::assertInstanceOf($expected, $r->getValue($instance), $message);
+    }
+
+    /**
+     * @param mixed  $expected Expected value
+     * @param object $instance Instance composing attribute to test
+     */
+    public static function assertAttributeSame($expected, string $attributeName, $instance, string $message = ''): void
+    {
+        $r = new ReflectionProperty($instance, $attributeName);
+        $r->setAccessible(true);
+        Assert::assertSame($expected, $r->getValue($instance), $message);
+    }
+}

--- a/test/Command/ReloadCommandFactoryTest.php
+++ b/test/Command/ReloadCommandFactoryTest.php
@@ -12,6 +12,7 @@ namespace MezzioTest\Swoole\Command;
 
 use Mezzio\Swoole\Command\ReloadCommand;
 use Mezzio\Swoole\Command\ReloadCommandFactory;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -20,6 +21,8 @@ use const SWOOLE_PROCESS;
 
 class ReloadCommandFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     public function testFactoryUsesDefaultsToCreateCommandWhenNoConfigPresent()
     {
         $container = $this->prophesize(ContainerInterface::class);

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace MezzioTest\Swoole\Command;
 
 use Mezzio\Swoole\Command\ReloadCommand;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -27,6 +28,7 @@ use const SWOOLE_PROCESS;
 
 class ReloadCommandTest extends TestCase
 {
+    use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
     protected function setUp(): void

--- a/test/Command/StartCommandFactoryTest.php
+++ b/test/Command/StartCommandFactoryTest.php
@@ -12,11 +12,14 @@ namespace MezzioTest\Swoole\Command;
 
 use Mezzio\Swoole\Command\StartCommand;
 use Mezzio\Swoole\Command\StartCommandFactory;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 class StartCommandFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     public function testFactoryProducesCommand()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();

--- a/test/Command/StartCommandTest.php
+++ b/test/Command/StartCommandTest.php
@@ -14,6 +14,7 @@ use Mezzio\Application;
 use Mezzio\MiddlewareFactory;
 use Mezzio\Swoole\Command\StartCommand;
 use Mezzio\Swoole\PidManager;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ProphecyInterface;
@@ -34,6 +35,7 @@ use const PATH_SEPARATOR;
 
 class StartCommandTest extends TestCase
 {
+    use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
     protected function setUp(): void

--- a/test/Command/StatusCommandFactoryTest.php
+++ b/test/Command/StatusCommandFactoryTest.php
@@ -13,11 +13,14 @@ namespace MezzioTest\Swoole\Command;
 use Mezzio\Swoole\Command\StatusCommand;
 use Mezzio\Swoole\Command\StatusCommandFactory;
 use Mezzio\Swoole\PidManager;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 class StatusCommandFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     public function testFactoryProducesCommand()
     {
         $pidManager = $this->prophesize(PidManager::class)->reveal();

--- a/test/Command/StatusCommandTest.php
+++ b/test/Command/StatusCommandTest.php
@@ -12,6 +12,7 @@ namespace MezzioTest\Swoole\Command;
 
 use Mezzio\Swoole\Command\StatusCommand;
 use Mezzio\Swoole\PidManager;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
@@ -22,6 +23,7 @@ use function getmypid;
 
 class StatusCommandTest extends TestCase
 {
+    use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
     protected function setUp(): void

--- a/test/Command/StopCommandFactoryTest.php
+++ b/test/Command/StopCommandFactoryTest.php
@@ -13,11 +13,14 @@ namespace MezzioTest\Swoole\Command;
 use Mezzio\Swoole\Command\StopCommand;
 use Mezzio\Swoole\Command\StopCommandFactory;
 use Mezzio\Swoole\PidManager;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 class StopCommandFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     public function testFactoryProducesCommand()
     {
         $pidManager = $this->prophesize(PidManager::class)->reveal();

--- a/test/Command/StopCommandTest.php
+++ b/test/Command/StopCommandTest.php
@@ -12,6 +12,7 @@ namespace MezzioTest\Swoole\Command;
 
 use Mezzio\Swoole\Command\StopCommand;
 use Mezzio\Swoole\PidManager;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\Console\Command\Command;
@@ -22,6 +23,7 @@ use function getmypid;
 
 class StopCommandTest extends TestCase
 {
+    use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
     protected function setUp(): void

--- a/test/HotCodeReload/ReloaderFactoryTest.php
+++ b/test/HotCodeReload/ReloaderFactoryTest.php
@@ -14,11 +14,14 @@ use Laminas\ServiceManager\ServiceManager;
 use Mezzio\Swoole\HotCodeReload\FileWatcherInterface;
 use Mezzio\Swoole\HotCodeReload\ReloaderFactory;
 use Mezzio\Swoole\Log\StdoutLogger;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 class ReloaderFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     /** @var ServiceManager */
     private $container;
 

--- a/test/Log/AccessLogFactoryTest.php
+++ b/test/Log/AccessLogFactoryTest.php
@@ -15,12 +15,14 @@ use Mezzio\Swoole\Log\AccessLogFormatter;
 use Mezzio\Swoole\Log\AccessLogFormatterInterface;
 use Mezzio\Swoole\Log\Psr3AccessLogDecorator;
 use Mezzio\Swoole\Log\StdoutLogger;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Zend\Expressive\Swoole\Log\AccessLogFormatterInterface as LegacyAccessLogFormatterInterface;
 
 class AccessLogFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
     use LoggerFactoryHelperTrait;
 
     public function testCreatesDecoratorWithStdoutLoggerAndAccessLogFormatterWhenNoConfigLoggerOrFormatterPresent()

--- a/test/Log/Psr3AccessLogDecoratorTest.php
+++ b/test/Log/Psr3AccessLogDecoratorTest.php
@@ -14,6 +14,7 @@ use Mezzio\Swoole\Log\AccessLogDataMap;
 use Mezzio\Swoole\Log\AccessLogFormatterInterface;
 use Mezzio\Swoole\Log\Psr3AccessLogDecorator;
 use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface as Psr7Response;
@@ -24,6 +25,8 @@ use Swoole\Http\Request;
 
 class Psr3AccessLogDecoratorTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     protected function setUp(): void
     {
         $this->psr3Logger     = $this->prophesize(LoggerInterface::class);
@@ -92,9 +95,9 @@ class Psr3AccessLogDecoratorTest extends TestCase
             ->format(
                 Argument::that(static function ($mapper) use ($request, $response) {
                     TestCase::assertInstanceOf(AccessLogDataMap::class, $mapper);
-                    TestCase::assertAttributeSame($request, 'request', $mapper);
-                    TestCase::assertAttributeSame($response->reveal(), 'staticResource', $mapper);
-                    TestCase::assertAttributeSame(false, 'useHostnameLookups', $mapper);
+                    Psr3AccessLogDecoratorTest::assertAttributeSame($request, 'request', $mapper);
+                    Psr3AccessLogDecoratorTest::assertAttributeSame($response->reveal(), 'staticResource', $mapper);
+                    Psr3AccessLogDecoratorTest::assertAttributeSame(false, 'useHostnameLookups', $mapper);
                     return true;
                 })
             )
@@ -127,9 +130,9 @@ class Psr3AccessLogDecoratorTest extends TestCase
             ->format(
                 Argument::that(static function ($mapper) use ($request, $response) {
                     TestCase::assertInstanceOf(AccessLogDataMap::class, $mapper);
-                    TestCase::assertAttributeSame($request, 'request', $mapper);
-                    TestCase::assertAttributeSame($response->reveal(), 'psrResponse', $mapper);
-                    TestCase::assertAttributeSame(false, 'useHostnameLookups', $mapper);
+                    Psr3AccessLogDecoratorTest::assertAttributeSame($request, 'request', $mapper);
+                    Psr3AccessLogDecoratorTest::assertAttributeSame($response->reveal(), 'psrResponse', $mapper);
+                    Psr3AccessLogDecoratorTest::assertAttributeSame(false, 'useHostnameLookups', $mapper);
                     return true;
                 })
             )

--- a/test/StaticMappedResourceHandlerFactoryTest.php
+++ b/test/StaticMappedResourceHandlerFactoryTest.php
@@ -30,6 +30,8 @@ use function sprintf;
 
 class StaticMappedResourceHandlerFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     protected function setUp(): void
     {
         $this->container       = $this->prophesize(ContainerInterface::class);

--- a/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
+++ b/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
@@ -13,12 +13,14 @@ namespace MezzioTest\Swoole\StaticResourceHandler;
 use Mezzio\Swoole\StaticResourceHandler\ContentTypeFilterMiddleware;
 use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
 use MezzioTest\Swoole\AssertResponseTrait;
+use MezzioTest\Swoole\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Swoole\Http\Request;
 
 class ContentTypeFilterMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
+    use AttributeAssertionTrait;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandlerFactoryTest.php
+++ b/test/StaticResourceHandlerFactoryTest.php
@@ -21,6 +21,8 @@ use function sprintf;
 
 class StaticResourceHandlerFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     protected function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);

--- a/test/SwooleRequestHandlerRunnerFactoryTest.php
+++ b/test/SwooleRequestHandlerRunnerFactoryTest.php
@@ -29,6 +29,8 @@ use Zend\Expressive\Swoole\Log\AccessLogInterface as LegacyAccessLogInterface;
 
 class SwooleRequestHandlerRunnerFactoryTest extends TestCase
 {
+    use AttributeAssertionTrait;
+
     protected function setUp(): void
     {
         $this->applicationPipeline = $this->prophesize(ApplicationPipeline::class);


### PR DESCRIPTION
We've had a number of warnings from PHPUnit about usage of deprecated assertions.
However, in many cases, there is no easy way to test that attributes were set other than reflection.
This patch adds an `AttributeAssertionTrait` that recreates the ones we use, and is now composed in test cases where the assertions are used.
