### PR TITLE
Enable SwooleEmitter to work with CallbackStreams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#31](https://github.com/mezzio/mezzio-swoole/pull/31) provides a fix to the `SwooleEmitter to allow it to work properly with callback streams. It does so by only rewinding the stream if it is seekable, and calling `Swoole\Htp\Response::end()` with the discovered `$body` directly if it is not marked readable (forcing it into string representation).
 
 ## 2.8.0 - 2020-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,28 +83,6 @@ Feature release (minor)
 
  - [22: Add Mapped Document Roots functionality](https://github.com/mezzio/mezzio-swoole/pull/22) thanks to @jasonterando
 
-## 2.6.7 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
-
-### Fixed
-
-- Nothing.
-
 ## 2.6.6 - 2020-06-17
 
 ### Added
@@ -542,7 +520,7 @@ Feature release (minor)
 ### Removed
 
 - [zendframework/zend-expressive-swoole#40](https://github.com/zendframework/zend-expressive-swoole/pull/40) removes the `Mezzio\Swoole\ServerFactory` and
-  `ServerFactoryFactory` classes, as well as the `Mezzio\Swoole\ServerFactory` 
+  `ServerFactoryFactory` classes, as well as the `Mezzio\Swoole\ServerFactory`
   service. Users should instead reference the `Swoole\Http\Server` service,
   which is now registered via the `Mezzio\Swoole\HttpServerFactory`
   factory, detailed in the "Added" section above.

--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -85,7 +85,7 @@ class SwooleEmitter implements EmitterInterface
         }
 
         if (! $body->isReadable()) {
-            $this->swooleResponse->end($body);
+            $this->swooleResponse->end((string) $body);
             return;
         }
 

--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -79,7 +79,15 @@ class SwooleEmitter implements EmitterInterface
     private function emitBody(ResponseInterface $response): void
     {
         $body = $response->getBody();
-        $body->rewind();
+
+        if ($body->isSeekable()) {
+            $body->rewind();
+        }
+
+        if (! $body->isReadable()) {
+            $this->swooleResponse->end($body);
+            return;
+        }
 
         if ($body->getSize() <= static::CHUNK_SIZE) {
             $this->swooleResponse->end($body->getContents());

--- a/test/SwooleEmitterTest.php
+++ b/test/SwooleEmitterTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace MezzioTest\Swoole;
 
+use Laminas\Diactoros\CallbackStream;
 use Laminas\Diactoros\Response;
 use Mezzio\Swoole\SwooleEmitter;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -156,5 +157,30 @@ class SwooleEmitterTest extends TestCase
             ->method('end');
 
         $this->assertTrue($this->emitter->emit($response));
+    }
+
+    public function testEmitCallbackStream()
+    {
+        $content  = 'content';
+        $callable = function () use ($content) {
+            return $content;
+        };
+
+        $response = (new Response())
+            ->withBody(new CallbackStream($callable))
+            ->withStatus(200)
+            ->withAddedHeader('Content-Type', 'text/plain');
+
+        $this->assertTrue($this->emitter->emit($response));
+
+        $this->swooleResponse
+            ->status(200)
+            ->shouldHaveBeenCalled();
+        $this->swooleResponse
+            ->header('Content-Type', 'text/plain')
+            ->shouldHaveBeenCalled();
+        $this->swooleResponse
+            ->end($content)
+            ->shouldHaveBeenCalled();
     }
 }

--- a/test/SwooleEmitterTest.php
+++ b/test/SwooleEmitterTest.php
@@ -159,10 +159,10 @@ class SwooleEmitterTest extends TestCase
         $this->assertTrue($this->emitter->emit($response));
     }
 
-    public function testEmitCallbackStream()
+    public function testEmitCallbackStream(): void
     {
         $content  = 'content';
-        $callable = function () use ($content) {
+        $callable = function () use ($content): string {
             return $content;
         };
 
@@ -171,16 +171,19 @@ class SwooleEmitterTest extends TestCase
             ->withStatus(200)
             ->withAddedHeader('Content-Type', 'text/plain');
 
-        $this->assertTrue($this->emitter->emit($response));
+        $this->swooleResponse
+            ->expects($this->once())
+            ->method('status')
+            ->with(200);
+        $this->swooleResponse
+            ->expects($this->once())
+            ->method('header')
+            ->with('Content-Type', 'text/plain');
+        $this->swooleResponse
+            ->expects($this->once())
+            ->method('end')
+            ->with($content);
 
-        $this->swooleResponse
-            ->status(200)
-            ->shouldHaveBeenCalled();
-        $this->swooleResponse
-            ->header('Content-Type', 'text/plain')
-            ->shouldHaveBeenCalled();
-        $this->swooleResponse
-            ->end($content)
-            ->shouldHaveBeenCalled();
+        $this->assertTrue($this->emitter->emit($response));
     }
 }


### PR DESCRIPTION
This patch enables the SwooleEmitter to properly work with CallbackStreams. Using a CallbackStream as a response body will currently result in an exception due to the fact that callback streams aren't seekable but the Emitter rewinds regardless.

Adds a tests case with a CallbackStream and an expected happy path route through the SwooleEmitter::emitBody method.

I ran into this issue whilst utilizing the https://github.com/harikt/psr7-asset, which uses a CallbackStream