### PR TITLE
PHP 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,12 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest
@@ -33,15 +27,20 @@ matrix:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
+    - php: nightly
+      env:
+        - DEPS=lowest
+    - php: nightly
+      env:
+        - DEPS=latest
 
 before_install:
   - sh -c "mkdir -p ${TRAVIS_BUILD_DIR}/.travis/module-cache/$(php-config --vernum)"
-  - MODULES="swoole.so:swoole inotify.so:inotify" ./.travis/modulecache.sh
+  - MODULES="inotify.so:inotify swoole.so:swoole" ./.travis/modulecache.sh
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#33](https://github.com/mezzio/mezzio-swoole/pull/33) adds support for PHP 8.
 
 ### Changed
 
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- [#33](https://github.com/mezzio/mezzio-swoole/pull/33) removes support for Swoole versions prior to 4.5.5.
+
+- [#33](https://github.com/mezzio/mezzio-swoole/pull/33) removes support for PHP 7.2.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "extra": {
     },
     "require": {
-        "php": "^7.2",
-        "ext-swoole": "^4.4.6",
+        "php": "^7.3 || ~8.0.0",
+        "ext-swoole": "^4.5.5",
         "composer/package-versions-deprecated": "^1.11",
         "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-diactoros": "^1.8 || ^2.0",
@@ -45,11 +45,8 @@
         "filp/whoops": "^2.1",
         "laminas/laminas-coding-standard": "~2.1.0",
         "laminas/laminas-servicemanager": "^3.3",
-        "phpunit/phpunit": "^8.5.2",
-        "swoole/ide-helper": "^4.5"
-    },
-    "conflict": {
-        "phpspec/prophecy": "<1.10.2"
+        "phpunit/phpunit": "^9.3",
+        "swoole/ide-helper": "^4.5.5"
     },
     "suggest": {
         "ext-inotify": "To use inotify based file watcher. Required for hot code reloading."

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,4 +17,9 @@
 
     <!-- Include all rules from Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard" />
+
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>test/Log/AccessLogFormatterTest.php</exclude-pattern>
+        <exclude-pattern>test/SwooleRequestHandlerRunnerFactoryTest.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="mezzio-swoole">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="mezzio-swoole">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Log/StdoutLogger.php
+++ b/src/Log/StdoutLogger.php
@@ -13,6 +13,8 @@ namespace Mezzio\Swoole\Log;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
+use function is_array;
+use function is_string;
 use function printf;
 use function sprintf;
 use function str_replace;
@@ -75,6 +77,7 @@ class StdoutLogger implements LoggerInterface
     public function log($level, $message, array $context = [])
     {
         foreach ($context as $key => $value) {
+            $value   = is_string($value) || is_array($value) ? $value : (string) $value;
             $search  = sprintf('{%s}', $key);
             $message = str_replace($search, $value, $message);
         }

--- a/test/AssertResponseTrait.php
+++ b/test/AssertResponseTrait.php
@@ -120,7 +120,7 @@ trait AssertResponseTrait
             $regexp
         );
 
-        Assert::assertRegexp($regexp, $value, $message);
+        Assert::assertMatchesRegularExpression($regexp, $value, $message);
     }
 
     public function assertShouldSendContent(StaticResourceResponse $response, string $message = ''): void

--- a/test/Command/ReloadCommandFactoryTest.php
+++ b/test/Command/ReloadCommandFactoryTest.php
@@ -25,13 +25,12 @@ class ReloadCommandFactoryTest extends TestCase
 
     public function testFactoryUsesDefaultsToCreateCommandWhenNoConfigPresent()
     {
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('config')->willReturn(false);
-        $container->get('config')->shouldNotBeCalled();
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->with('config')->willReturn(false);
 
         $factory = new ReloadCommandFactory();
 
-        $command = $factory($container->reveal());
+        $command = $factory($container);
 
         $this->assertInstanceOf(ReloadCommand::class, $command);
     }
@@ -60,13 +59,13 @@ class ReloadCommandFactoryTest extends TestCase
      */
     public function testFactoryUsesConfigToCreateCommandWhenPresent(array $config, int $mode)
     {
-        $container = $this->prophesize(ContainerInterface::class);
-        $container->has('config')->willReturn(true);
-        $container->get('config')->willReturn($config);
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->with('config')->willReturn(true);
+        $container->method('get')->with('config')->willReturn($config);
 
         $factory = new ReloadCommandFactory();
 
-        $command = $factory($container->reveal());
+        $command = $factory($container);
 
         $this->assertInstanceOf(ReloadCommand::class, $command);
         $this->assertAttributeSame($mode, 'serverMode', $command);

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -12,9 +12,8 @@ namespace MezzioTest\Swoole\Command;
 
 use Mezzio\Swoole\Command\ReloadCommand;
 use MezzioTest\Swoole\AttributeAssertionTrait;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -31,22 +30,26 @@ class ReloadCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
+    /** @var InputInterface|MockObject */
+    private $input;
+
+    /** @var OutputInterface|MockObject */
+    private $output;
+
     protected function setUp(): void
     {
-        $this->input  = $this->prophesize(InputInterface::class);
-        $this->output = $this->prophesize(OutputInterface::class);
+        $this->input  = $this->createMock(InputInterface::class);
+        $this->output = $this->createMock(OutputInterface::class);
     }
 
     /**
-     * @return Application|ObjectProphecy
+     * @return Application|MockObject
      */
     public function mockApplication()
     {
-        $helperSet   = $this->prophesize(HelperSet::class);
-        $application = $this->prophesize(Application::class);
-        $application
-            ->getHelperSet()
-            ->will([$helperSet, 'reveal']);
+        $helperSet   = $this->createMock(HelperSet::class);
+        $application = $this->createMock(Application::class);
+        $application->method('getHelperSet')->willReturn($helperSet);
         return $application;
     }
 
@@ -101,189 +104,182 @@ class ReloadCommandTest extends TestCase
     public function testExecuteEndsWithErrorWhenServerModeIsNotProcessMode()
     {
         $command = new ReloadCommand(SWOOLE_BASE);
-        $execute = $this->reflectMethod($command, 'execute');
-
-        $this->assertSame(1, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
 
         $this->output
-            ->writeln(Argument::containingString('not configured to run in SWOOLE_PROCESS mode'))
-            ->shouldHaveBeenCalled();
+            ->expects($this->once())
+            ->method('writeln')
+            ->with($this->stringContains('not configured to run in SWOOLE_PROCESS mode'));
+
+        $execute = $this->reflectMethod($command, 'execute');
+        $this->assertSame(1, $execute->invoke($command, $this->input, $this->output));
     }
 
     public function testExecuteEndsWithErrorWhenStopCommandFails()
     {
         $command = new ReloadCommand(SWOOLE_PROCESS);
 
-        $stopCommand = $this->prophesize(Command::class);
+        $stopCommand = $this->createMock(Command::class);
         $stopCommand
-            ->run(
-                Argument::that(static function ($arg) {
-                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
-                    TestCase::assertSame('stop', (string) $arg);
-                    return $arg;
+            ->method('run')
+            ->with(
+                $this->callback(static function (ArrayInput $arg) {
+                    return 'stop' === (string) $arg;
                 }),
-                Argument::that([$this->output, 'reveal'])
+                $this->output
             )
             ->willReturn(1);
 
         $application = $this->mockApplication();
-        $application->find('stop')->will([$stopCommand, 'reveal']);
+        $application->method('find')->with('stop')->willReturn($stopCommand);
 
-        $command->setApplication($application->reveal());
+        $command->setApplication($application);
+
+        $this->output
+            ->expects($this->exactly(2))
+            ->method('writeln')
+            ->withConsecutive(
+                [$this->stringContains('Reloading server')],
+                [$this->stringContains('Cannot reload server: unable to stop')]
+            );
 
         $execute = $this->reflectMethod($command, 'execute');
-        $this->assertSame(1, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
-
-        $this->output
-            ->writeln(Argument::containingString('Reloading server'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->writeln(Argument::containingString('Cannot reload server: unable to stop'))
-            ->shouldHaveBeenCalled();
+        $this->assertSame(1, $execute->invoke($command, $this->input, $this->output));
     }
 
     public function testExecuteEndsWithErrorWhenStartCommandFails()
     {
         $command = new ReloadCommand(SWOOLE_PROCESS);
 
-        $this->input->getOption('num-workers')->willReturn(5);
+        $this->input->method('getOption')->with('num-workers')->willReturn(5);
 
-        $stopCommand = $this->prophesize(Command::class);
+        $stopCommand = $this->createMock(Command::class);
         $stopCommand
-            ->run(
-                Argument::that(static function ($arg) {
-                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
-                    TestCase::assertSame('stop', (string) $arg);
-                    return $arg;
+            ->method('run')
+            ->with(
+                $this->callback(static function (ArrayInput $arg) {
+                    return 'stop' === (string) $arg;
                 }),
-                Argument::that([$this->output, 'reveal'])
+                $this->output
             )
             ->willReturn(0);
 
-        $startCommand = $this->prophesize(Command::class);
+        $startCommand = $this->createMock(Command::class);
         $startCommand
-            ->run(
-                Argument::that(static function ($arg) {
-                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
-                    TestCase::assertSame('start --daemonize=1 --num-workers=5', (string) $arg);
-                    return $arg;
+            ->method('run')
+            ->with(
+                $this->callback(static function (ArrayInput $arg) {
+                    return 'start --daemonize=1 --num-workers=5' === (string) $arg;
                 }),
-                Argument::that([$this->output, 'reveal'])
+                $this->output
             )
             ->willReturn(1);
 
         $application = $this->mockApplication();
-        $application->find('stop')->will([$stopCommand, 'reveal']);
-        $application->find('start')->will([$startCommand, 'reveal']);
+        $application
+            ->expects($this->exactly(2))
+            ->method('find')
+            ->withConsecutive(
+                ['stop'],
+                ['start']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $stopCommand,
+                $startCommand
+            );
 
-        $command->setApplication($application->reveal());
+        $command->setApplication($application);
+
+        $this->output
+            ->expects($this->exactly(4))
+            ->method('writeln')
+            ->withConsecutive(
+                [$this->stringContains('Reloading server')],
+                [$this->stringContains('[DONE]')],
+                [$this->stringContains('Starting server')],
+                [$this->stringContains('Cannot reload server: unable to start')]
+            );
+
+        $this->output
+            ->expects($this->exactly(6))
+            ->method('write')
+            ->withConsecutive(
+                [$this->stringContains('Waiting for 5 seconds')],
+                [$this->stringContains('<info>.</info>')],
+                [$this->stringContains('<info>.</info>')],
+                [$this->stringContains('<info>.</info>')],
+                [$this->stringContains('<info>.</info>')],
+                [$this->stringContains('<info>.</info>')]
+            );
 
         $execute = $this->reflectMethod($command, 'execute');
-        $this->assertSame(1, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
-
-        $this->output
-            ->writeln(Argument::containingString('Reloading server'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->write(Argument::containingString('Waiting for 5 seconds'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->write(Argument::containingString('<info>.</info>'))
-            ->shouldHaveBeenCalledTimes(5);
-
-        $this->output
-            ->writeln(Argument::containingString('[DONE]'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->writeln(Argument::containingString('Starting server'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->writeln(Argument::containingString('Cannot reload server: unable to start'))
-            ->shouldHaveBeenCalled();
+        $this->assertSame(1, $execute->invoke($command, $this->input, $this->output));
     }
 
     public function testExecuteEndsWithSuccessWhenBothStopAndStartCommandsSucceed()
     {
         $command = new ReloadCommand(SWOOLE_PROCESS);
 
-        $this->input->getOption('num-workers')->willReturn(5);
+        $this->input->method('getOption')->with('num-workers')->willReturn(5);
 
-        $stopCommand = $this->prophesize(Command::class);
+        $stopCommand = $this->createMock(Command::class);
         $stopCommand
-            ->run(
-                Argument::that(static function ($arg) {
-                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
-                    TestCase::assertSame('stop', (string) $arg);
-                    return $arg;
+            ->method('run')
+            ->with(
+                $this->callback(static function (ArrayInput $arg) {
+                    return 'stop' === (string) $arg;
                 }),
-                Argument::that([$this->output, 'reveal'])
+                $this->output
             )
             ->willReturn(0);
 
-        $startCommand = $this->prophesize(Command::class);
+        $startCommand = $this->createMock(Command::class);
         $startCommand
-            ->run(
-                Argument::that(static function ($arg) {
-                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
-                    TestCase::assertSame('start --daemonize=1 --num-workers=5', (string) $arg);
-                    return $arg;
+            ->method('run')
+            ->with(
+                $this->callback(static function (ArrayInput $arg) {
+                    return 'start --daemonize=1 --num-workers=5' === (string) $arg;
                 }),
-                Argument::that([$this->output, 'reveal'])
+                $this->output
             )
             ->willReturn(0);
 
         $application = $this->mockApplication();
-        $application->find('stop')->will([$stopCommand, 'reveal']);
-        $application->find('start')->will([$startCommand, 'reveal']);
+        $application
+            ->expects($this->exactly(2))
+            ->method('find')
+            ->withConsecutive(
+                ['stop'],
+                ['start']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $stopCommand,
+                $startCommand
+            );
 
-        $command->setApplication($application->reveal());
+        $this->output
+            ->expects($this->exactly(3))
+            ->method('writeln')
+            ->withConsecutive(
+                [$this->stringContains('Reloading server')],
+                [$this->stringContains('[DONE]')],
+                [$this->stringContains('Starting server')]
+            );
+
+        $this->output
+            ->expects($this->exactly(6))
+            ->method('write')
+            ->withConsecutive(
+                [$this->stringContains('Waiting for 5 seconds')],
+                [$this->stringContains('<info>.</info>')],
+                [$this->stringContains('<info>.</info>')],
+                [$this->stringContains('<info>.</info>')],
+                [$this->stringContains('<info>.</info>')],
+                [$this->stringContains('<info>.</info>')]
+            );
+
+        $command->setApplication($application);
 
         $execute = $this->reflectMethod($command, 'execute');
-        $this->assertSame(0, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
-
-        $this->output
-            ->writeln(Argument::containingString('Reloading server'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->write(Argument::containingString('Waiting for 5 seconds'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->write(Argument::containingString('<info>.</info>'))
-            ->shouldHaveBeenCalledTimes(5);
-
-        $this->output
-            ->writeln(Argument::containingString('[DONE]'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->writeln(Argument::containingString('Starting server'))
-            ->shouldHaveBeenCalled();
-
-        $this->output
-            ->writeln(Argument::containingString('Cannot reload server'))
-            ->shouldNotHaveBeenCalled();
+        $this->assertSame(0, $execute->invoke($command, $this->input, $this->output));
     }
 }

--- a/test/Command/StartCommandFactoryTest.php
+++ b/test/Command/StartCommandFactoryTest.php
@@ -22,7 +22,7 @@ class StartCommandFactoryTest extends TestCase
 
     public function testFactoryProducesCommand()
     {
-        $container = $this->prophesize(ContainerInterface::class)->reveal();
+        $container = $this->createMock(ContainerInterface::class);
 
         $factory = new StartCommandFactory();
 

--- a/test/Command/StartCommandTest.php
+++ b/test/Command/StartCommandTest.php
@@ -15,9 +15,8 @@ use Mezzio\MiddlewareFactory;
 use Mezzio\Swoole\Command\StartCommand;
 use Mezzio\Swoole\PidManager;
 use MezzioTest\Swoole\AttributeAssertionTrait;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
-use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Container\ContainerInterface;
 use Swoole\Http\Server as SwooleHttpServer;
 use Symfony\Component\Console\Command\Command;
@@ -25,6 +24,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_key_exists;
 use function get_include_path;
 use function getmypid;
 use function realpath;
@@ -38,12 +38,24 @@ class StartCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
+    /** @var ContainerInterface|MockObject */
+    private $container;
+
+    /** @var InputInterface|MockObject */
+    private $input;
+
+    /** @var OutputInterface|MockObject */
+    private $output;
+
+    /** @var PidManager|MockObject */
+    private $pidManager;
+
     protected function setUp(): void
     {
-        $this->container  = $this->prophesize(ContainerInterface::class);
-        $this->input      = $this->prophesize(InputInterface::class);
-        $this->output     = $this->prophesize(OutputInterface::class);
-        $this->pidManager = $this->prophesize(PidManager::class);
+        $this->container  = $this->createMock(ContainerInterface::class);
+        $this->input      = $this->createMock(InputInterface::class);
+        $this->output     = $this->createMock(OutputInterface::class);
+        $this->pidManager = $this->createMock(PidManager::class);
 
         $this->originalIncludePath = get_include_path();
         set_include_path(sprintf(
@@ -59,19 +71,10 @@ class StartCommandTest extends TestCase
         set_include_path($this->originalIncludePath);
     }
 
-    /** @param object $instance */
-    public function pushServiceToContainer(string $name, $instance): void
-    {
-        if ($instance instanceof ProphecyInterface) {
-            $instance = $instance->reveal();
-        }
-        $this->container->get($name)->willReturn($instance);
-    }
-
     public function testConstructorAcceptsContainer(): StartCommand
     {
-        $command = new StartCommand($this->container->reveal());
-        $this->assertAttributeSame($this->container->reveal(), 'container', $command);
+        $command = new StartCommand($this->container);
+        $this->assertAttributeSame($this->container, 'container', $command);
         return $command;
     }
 
@@ -143,42 +146,34 @@ class StartCommandTest extends TestCase
 
     public function testExecuteReturnsErrorIfServerIsRunningInBaseMode()
     {
-        $this->pidManager->read()->willReturn([getmypid(), null]);
-        $this->pushServiceToContainer(PidManager::class, $this->pidManager);
+        $this->pidManager->method('read')->willReturn([getmypid(), null]);
+        $this->container->method('get')->with(PidManager::class)->willReturn($this->pidManager);
 
-        $command = new StartCommand($this->container->reveal());
-
-        $execute = $this->reflectMethod($command, 'execute');
-
-        $this->assertSame(1, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
+        $command = new StartCommand($this->container);
 
         $this->output
-            ->writeln(Argument::containingString('Server is already running'))
-            ->shouldHaveBeenCalled();
+            ->expects($this->once())
+            ->method('writeln')
+            ->with($this->stringContains('Server is already running'));
+
+        $execute = $this->reflectMethod($command, 'execute');
+        $this->assertSame(1, $execute->invoke($command, $this->input, $this->output));
     }
 
     public function testExecuteReturnsErrorIfServerIsRunningInProcessMode()
     {
-        $this->pidManager->read()->willReturn([1000000, getmypid()]);
-        $this->pushServiceToContainer(PidManager::class, $this->pidManager);
+        $this->pidManager->method('read')->willReturn([1000000, getmypid()]);
+        $this->container->method('get')->with(PidManager::class)->willReturn($this->pidManager);
 
-        $command = new StartCommand($this->container->reveal());
-
-        $execute = $this->reflectMethod($command, 'execute');
-
-        $this->assertSame(1, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
+        $command = new StartCommand($this->container);
 
         $this->output
-            ->writeln(Argument::containingString('Server is already running'))
-            ->shouldHaveBeenCalled();
+            ->expects($this->once())
+            ->method('writeln')
+            ->with($this->stringContains('Server is already running'));
+
+        $execute = $this->reflectMethod($command, 'execute');
+        $this->assertSame(1, $execute->invoke($command, $this->input, $this->output));
     }
 
     public function noRunningProcesses(): iterable
@@ -194,46 +189,50 @@ class StartCommandTest extends TestCase
      */
     public function testExecuteRunsApplicationIfServerIsNotCurrentlyRunning(array $pids)
     {
-        $this->input->getOption('daemonize')->willReturn(true);
-        $this->input->getOption('num-workers')->willReturn(6);
+        $httpServer        = $this->createMock(TestAsset\HttpServer::class);
+        $middlewareFactory = $this->createMock(MiddlewareFactory::class);
+        $application       = $this->createMock(Application::class);
 
-        $this->pidManager->read()->willReturn($pids);
-        $this->pushServiceToContainer(PidManager::class, $this->pidManager);
+        $this->input
+            ->method('getOption')
+            ->will($this->returnValueMap([
+                ['daemonize', true],
+                ['num-workers', 6],
+            ]));
 
-        $httpServer = $this->prophesize(TestAsset\HttpServer::class);
-        $this->pushServiceToContainer(SwooleHttpServer::class, $httpServer);
+        $this->pidManager->method('read')->willReturn($pids);
 
-        $middlewareFactory = $this->prophesize(MiddlewareFactory::class);
-        $this->pushServiceToContainer(MiddlewareFactory::class, $middlewareFactory);
+        $httpServer
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->callback(static function (array $options) {
+                return array_key_exists('daemonize', $options)
+                    && array_key_exists('worker_num', $options)
+                    && true === $options['daemonize']
+                    && 6 === $options['worker_num'];
+            }));
 
-        $application = $this->prophesize(Application::class);
-        $this->pushServiceToContainer(Application::class, $application);
+        $application->expects($this->once())->method('run');
 
-        $command = new StartCommand($this->container->reveal());
+        $this->output
+            ->expects($this->never())
+            ->method('writeln')
+            ->with($this->stringContains('Server is already running'));
+
+        $this->container
+            ->method('get')
+            ->will($this->returnValueMap([
+                [PidManager::class, $this->pidManager],
+                [SwooleHttpServer::class, $httpServer],
+                [MiddlewareFactory::class, $middlewareFactory],
+                [Application::class, $application],
+            ]));
+
+        $command = new StartCommand($this->container);
 
         $execute = $this->reflectMethod($command, 'execute');
 
-        $this->assertSame(0, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
-
-        $httpServer
-            ->set(Argument::that(static function ($options) {
-                TestCase::assertArrayHasKey('daemonize', $options);
-                TestCase::assertArrayHasKey('worker_num', $options);
-                TestCase::assertTrue($options['daemonize']);
-                TestCase::assertSame(6, $options['worker_num']);
-                return $options;
-            }))
-            ->shouldHaveBeenCalled();
-
-        $application->run()->shouldHaveBeenCalled();
-
-        $this->output
-            ->writeln(Argument::containingString('Server is already running'))
-            ->shouldNotHaveBeenCalled();
+        $this->assertSame(0, $execute->invoke($command, $this->input, $this->output));
     }
 
     /**
@@ -241,30 +240,25 @@ class StartCommandTest extends TestCase
      */
     public function testExecuteRunsApplicationWithoutSettingOptionsIfNoneProvided(array $pids)
     {
-        $this->input->getOption('daemonize')->willReturn(false);
-        $this->input->getOption('num-workers')->willReturn(null);
+        $this->input
+            ->method('getOption')
+            ->will($this->returnValueMap([
+                ['daemonize', false],
+                ['num-workers', null],
+            ]));
 
         [$command, $httpServer, $application] = $this->prepareSuccessfulStartCommand($pids);
 
-        $execute = $this->reflectMethod($command, 'execute');
-
-        $this->assertSame(0, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
-
-        $this->container->get(SwooleHttpServer::class)->shouldNotHaveBeenCalled();
-
-        $httpServer
-            ->set(Argument::any())
-            ->shouldNotHaveBeenCalled();
-
-        $application->run()->shouldHaveBeenCalled();
+        $httpServer->expects($this->never())->method('set');
+        $application->expects($this->once())->method('run');
 
         $this->output
-            ->writeln(Argument::containingString('Server is already running'))
-            ->shouldNotHaveBeenCalled();
+            ->expects($this->never())
+            ->method('writeln')
+            ->with($this->stringContains('Server is already running'));
+
+        $execute = $this->reflectMethod($command, 'execute');
+        $this->assertSame(0, $execute->invoke($command, $this->input, $this->output));
     }
 
     public function testExecutionDoesNotFailEvenIfProgrammaticConfigFilesDoNotExist()
@@ -274,29 +268,26 @@ class StartCommandTest extends TestCase
         [$command] = $this->prepareSuccessfulStartCommand([]);
 
         $execute = $this->reflectMethod($command, 'execute');
-
-        $this->assertSame(0, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
+        $this->assertSame(0, $execute->invoke($command, $this->input, $this->output));
     }
 
     private function prepareSuccessfulStartCommand(array $pids): array
     {
-        $this->pidManager->read()->willReturn($pids);
-        $this->pushServiceToContainer(PidManager::class, $this->pidManager);
+        $httpServer        = $this->createMock(TestAsset\HttpServer::class);
+        $middlewareFactory = $this->createMock(MiddlewareFactory::class);
+        $application       = $this->createMock(Application::class);
 
-        $httpServer = $this->prophesize(TestAsset\HttpServer::class);
-        $this->pushServiceToContainer(SwooleHttpServer::class, $httpServer);
+        $this->pidManager->method('read')->willReturn($pids);
+        $this->container
+            ->method('get')
+            ->will($this->returnValueMap([
+                [PidManager::class, $this->pidManager],
+                [SwooleHttpServer::class, $httpServer],
+                [MiddlewareFactory::class, $middlewareFactory],
+                [Application::class, $application],
+            ]));
 
-        $middlewareFactory = $this->prophesize(MiddlewareFactory::class);
-        $this->pushServiceToContainer(MiddlewareFactory::class, $middlewareFactory);
-
-        $application = $this->prophesize(Application::class);
-        $this->pushServiceToContainer(Application::class, $application);
-
-        $command = new StartCommand($this->container->reveal());
+        $command = new StartCommand($this->container);
 
         return [$command, $httpServer, $application];
     }

--- a/test/Command/StatusCommandFactoryTest.php
+++ b/test/Command/StatusCommandFactoryTest.php
@@ -23,13 +23,13 @@ class StatusCommandFactoryTest extends TestCase
 
     public function testFactoryProducesCommand()
     {
-        $pidManager = $this->prophesize(PidManager::class)->reveal();
-        $container  = $this->prophesize(ContainerInterface::class);
-        $container->get(PidManager::class)->willReturn($pidManager);
+        $pidManager = $this->createMock(PidManager::class);
+        $container  = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with(PidManager::class)->willReturn($pidManager);
 
         $factory = new StatusCommandFactory();
 
-        $command = $factory($container->reveal());
+        $command = $factory($container);
 
         $this->assertInstanceOf(StatusCommand::class, $command);
         $this->assertAttributeSame($pidManager, 'pidManager', $command);

--- a/test/Command/StopCommandFactoryTest.php
+++ b/test/Command/StopCommandFactoryTest.php
@@ -23,13 +23,13 @@ class StopCommandFactoryTest extends TestCase
 
     public function testFactoryProducesCommand()
     {
-        $pidManager = $this->prophesize(PidManager::class)->reveal();
-        $container  = $this->prophesize(ContainerInterface::class);
-        $container->get(PidManager::class)->willReturn($pidManager);
+        $pidManager = $this->createMock(PidManager::class);
+        $container  = $this->createMock(ContainerInterface::class);
+        $container->method('get')->with(PidManager::class)->willReturn($pidManager);
 
         $factory = new StopCommandFactory();
 
-        $command = $factory($container->reveal());
+        $command = $factory($container);
 
         $this->assertInstanceOf(StopCommand::class, $command);
         $this->assertAttributeSame($pidManager, 'pidManager', $command);

--- a/test/Log/AccessLogDataMapTest.php
+++ b/test/Log/AccessLogDataMapTest.php
@@ -19,8 +19,8 @@ class AccessLogDataMapTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->request  = $this->prophesize(SwooleHttpRequest::class)->reveal();
-        $this->response = $this->prophesize(ResponseInterface::class)->reveal();
+        $this->request  = $this->createMock(SwooleHttpRequest::class);
+        $this->response = $this->createMock(ResponseInterface::class);
     }
 
     public function provideServer(): iterable

--- a/test/Log/AccessLogFactoryTest.php
+++ b/test/Log/AccessLogFactoryTest.php
@@ -28,14 +28,12 @@ class AccessLogFactoryTest extends TestCase
     public function testCreatesDecoratorWithStdoutLoggerAndAccessLogFormatterWhenNoConfigLoggerOrFormatterPresent()
     {
         $factory = new AccessLogFactory();
-
-        $this->container->has(AccessLogFormatterInterface::class)->willReturn(false);
-
-        $this->container->has(LegacyAccessLogFormatterInterface::class)->willReturn(false);
-        $this->container->get(AccessLogFormatterInterface::class)->shouldNotBeCalled();
-        $this->container->get(LegacyAccessLogFormatterInterface::class)->shouldNotBeCalled();
-
-        $logger = $factory($this->createContainerMockWithConfigAndNotPsrLogger());
+        $logger  = $factory($this->createContainerMockWithConfigAndNotPsrLogger([
+            'has' => [
+                AccessLogFormatterInterface::class       => false,
+                LegacyAccessLogFormatterInterface::class => false,
+            ],
+        ]));
 
         $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
         $this->assertAttributeInstanceOf(StdoutLogger::class, 'logger', $logger);
@@ -45,14 +43,12 @@ class AccessLogFactoryTest extends TestCase
     public function testUsesConfiguredStandardLoggerServiceWhenPresent()
     {
         $factory = new AccessLogFactory();
-
-        $this->container->has(AccessLogFormatterInterface::class)->willReturn(false);
-
-        $this->container->has(LegacyAccessLogFormatterInterface::class)->willReturn(false);
-        $this->container->get(AccessLogFormatterInterface::class)->shouldNotBeCalled();
-        $this->container->get(LegacyAccessLogFormatterInterface::class)->shouldNotBeCalled();
-
-        $logger = $factory($this->createContainerMockWithConfigAndPsrLogger());
+        $logger  = $factory($this->createContainerMockWithConfigAndPsrLogger([
+            'has' => [
+                AccessLogFormatterInterface::class       => false,
+                LegacyAccessLogFormatterInterface::class => false,
+            ],
+        ]));
 
         $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
         $this->assertAttributeSame($this->logger, 'logger', $logger);
@@ -62,14 +58,12 @@ class AccessLogFactoryTest extends TestCase
     public function testUsesConfiguredCustomLoggerServiceWhenPresent()
     {
         $factory = new AccessLogFactory();
-
-        $this->container->has(AccessLogFormatterInterface::class)->willReturn(false);
-
-        $this->container->has(LegacyAccessLogFormatterInterface::class)->willReturn(false);
-        $this->container->get(AccessLogFormatterInterface::class)->shouldNotBeCalled();
-        $this->container->get(LegacyAccessLogFormatterInterface::class)->shouldNotBeCalled();
-
-        $logger = $factory($this->createContainerMockWithNamedLogger());
+        $logger  = $factory($this->createContainerMockWithNamedLogger([
+            'has' => [
+                AccessLogFormatterInterface::class       => false,
+                LegacyAccessLogFormatterInterface::class => false,
+            ],
+        ]));
 
         $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
         $this->assertAttributeSame($this->logger, 'logger', $logger);
@@ -79,11 +73,10 @@ class AccessLogFactoryTest extends TestCase
     public function testUsesConfiguredFormatterServiceWhenPresent()
     {
         $factory = new AccessLogFactory();
-
-        $this->container->has(AccessLogFormatterInterface::class)->willReturn(true);
-        $this->container->get(AccessLogFormatterInterface::class)->willReturn($this->formatter);
-
-        $logger = $factory($this->createContainerMockWithConfigAndNotPsrLogger());
+        $logger  = $factory($this->createContainerMockWithConfigAndNotPsrLogger([
+            'has' => [AccessLogFormatterInterface::class => true],
+            'get' => [AccessLogFormatterInterface::class => $this->formatter],
+        ]));
 
         $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
         $this->assertAttributeInstanceOf(StdoutLogger::class, 'logger', $logger);
@@ -93,23 +86,24 @@ class AccessLogFactoryTest extends TestCase
     public function testUsesConfigurationToSeedGeneratedLoggerAndFormatter()
     {
         $factory = new AccessLogFactory();
-
-        $this->container->has(AccessLogFormatterInterface::class)->willReturn(false);
-
-        $this->container->has(LegacyAccessLogFormatterInterface::class)->willReturn(false);
-        $this->container->get(AccessLogFormatterInterface::class)->shouldNotBeCalled();
-        $this->container->get(LegacyAccessLogFormatterInterface::class)->shouldNotBeCalled();
-
-        $logger = $factory($this->createContainerMockWithConfigAndNotPsrLogger([
-            'mezzio-swoole' => [
-                'swoole-http-server' => [
-                    'logger' => [
-                        'format'               => AccessLogFormatter::FORMAT_COMBINED,
-                        'use-hostname-lookups' => true,
+        $logger  = $factory($this->createContainerMockWithConfigAndNotPsrLogger(
+            [
+                'has' => [
+                    AccessLogFormatterInterface::class       => false,
+                    LegacyAccessLogFormatterInterface::class => false,
+                ],
+            ],
+            [
+                'mezzio-swoole' => [
+                    'swoole-http-server' => [
+                        'logger' => [
+                            'format'               => AccessLogFormatter::FORMAT_COMBINED,
+                            'use-hostname-lookups' => true,
+                        ],
                     ],
                 ],
             ],
-        ]));
+        ));
 
         $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
         $this->assertAttributeInstanceOf(StdoutLogger::class, 'logger', $logger);

--- a/test/Log/AccessLogFormatterTest.php
+++ b/test/Log/AccessLogFormatterTest.php
@@ -23,36 +23,43 @@ class AccessLogFormatterTest extends TestCase
     {
         $hostname = gethostname();
 
-        $dataMap = $this->prophesize(AccessLogDataMap::class);
-        $dataMap->getClientIp()->willReturn('127.0.0.10'); // %a
-        $dataMap->getLocalIp()->willReturn('127.0.0.1'); // %A
-        $dataMap->getBodySize('0')->willReturn('1234'); // %B
-        $dataMap->getBodySize('-')->willReturn('1234'); // %b
-        $dataMap->getRequestDuration('ms')->willReturn('4321'); // %D
-        $dataMap->getFilename()->willReturn(__FILE__); // %f
-        $dataMap->getRemoteHostname()->willReturn($hostname); // %h
-        $dataMap->getProtocol()->willReturn('HTTP/1.1'); // %H
-        $dataMap->getMethod()->willReturn('POST'); // %m
-        $dataMap->getPort('canonical')->willReturn('9000'); // %p
-        $dataMap->getQuery()->willReturn('?foo=bar'); // %q
-        $dataMap->getRequestLine()->willReturn('POST /path?foo=bar HTTP/1.1'); // %r
-        $dataMap->getStatus()->willReturn('202'); // %s
-        $dataMap->getRequestTime('begin:%d/%b/%Y:%H:%M:%S %z')->willReturn('[1234567890]'); // %t
-        $dataMap->getRequestDuration('s')->willReturn('22'); // %T
-        $dataMap->getRemoteUser()->willReturn('mezzio'); // %u
-        $dataMap->getPath()->willReturn('/path'); // %U
-        $dataMap->getHost()->willReturn('mezzio.local'); // %v
-        $dataMap->getServerName()->willReturn('mezzio.local'); // %V
-        $dataMap->getRequestMessageSize('-')->willReturn('78'); // %I
-        $dataMap->getResponseMessageSize('-')->willReturn('89'); // %O
-        $dataMap->getTransferredSize()->willReturn('123'); // %S
-        $dataMap->getCookie('cookie_name')->willReturn('chocolate'); // %{cookie_name}C
-        $dataMap->getEnv('env_name')->willReturn('php'); // %{env_name}e
-        $dataMap->getRequestHeader('X-Request-Header')->willReturn('request'); // %{X-Request-Header}i
-        $dataMap->getResponseHeader('X-Response-Header')->willReturn('response'); // %{X-Response-Header}o
-        $dataMap->getPort('local')->willReturn('9999'); // %{local}p
-        $dataMap->getRequestTime('end:sec')->willReturn('[1234567890]'); // %{end:sec}t
-        $dataMap->getRequestDuration('us')->willReturn('22'); // %{us}T
+        $dataMap = $this->createMock(AccessLogDataMap::class);
+        $dataMap->method('getClientIp')->willReturn('127.0.0.10'); // %a
+        $dataMap->method('getLocalIp')->willReturn('127.0.0.1'); // %A
+        $dataMap
+            ->method('getBodySize')
+            ->withConsecutive(['0'], ['-']) // %B / %b
+            ->willReturn('1234');
+        $dataMap
+            ->method('getRequestDuration')
+            ->withConsecutive(['ms'], ['s'], ['us']) // %D / %T / %{us}T
+            ->willReturnOnConsecutiveCalls('4321', '22', '22');
+        $dataMap->method('getFilename')->willReturn(__FILE__); // %f
+        $dataMap->method('getRemoteHostname')->willReturn($hostname); // %h
+        $dataMap->method('getProtocol')->willReturn('HTTP/1.1'); // %H
+        $dataMap->method('getMethod')->willReturn('POST'); // %m
+        $dataMap
+            ->method('getPort')
+            ->withConsecutive(['canonical'], ['local']) // %p / %{local}p
+            ->willReturnOnConsecutiveCalls('9000', '9999');
+        $dataMap->method('getQuery')->willReturn('?foo=bar'); // %q
+        $dataMap->method('getRequestLine')->willReturn('POST /path?foo=bar HTTP/1.1'); // %r
+        $dataMap->method('getStatus')->willReturn('202'); // %s
+        $dataMap
+            ->method('getRequestTime')
+            ->withConsecutive(['begin:%d/%b/%Y:%H:%M:%S %z'], ['end:sec']) // %t / %{end:sec}t
+            ->willReturnOnConsecutiveCalls('[1234567890]', '[1234567890]');
+        $dataMap->method('getRemoteUser')->willReturn('mezzio'); // %u
+        $dataMap->method('getPath')->willReturn('/path'); // %U
+        $dataMap->method('getHost')->willReturn('mezzio.local'); // %v
+        $dataMap->method('getServerName')->willReturn('mezzio.local'); // %V
+        $dataMap->method('getRequestMessageSize')->with('-')->willReturn(78); // %I
+        $dataMap->method('getResponseMessageSize')->with('-')->willReturn(89); // %O
+        $dataMap->method('getTransferredSize')->willReturn('123'); // %S
+        $dataMap->method('getCookie')->with('cookie_name')->willReturn('chocolate'); // %{cookie_name}C
+        $dataMap->method('getEnv')->with('env_name')->willReturn('php'); // %{env_name}e
+        $dataMap->method('getRequestHeader')->with('X-Request-Header')->willReturn('request'); // %{X-Request-Header}i
+        $dataMap->method('getResponseHeader')->with('X-Response-Header')->willReturn('response'); // %{X-Response-Header}o
 
         $format   = '%a %A %B %b %D %f %h %H %m %p %q %r %s %t %T %u %U %v %V %I %O %S'
             . ' %{cookie_name}C %{env_name}e %{X-Request-Header}i %{X-Response-Header}o'
@@ -92,7 +99,7 @@ class AccessLogFormatterTest extends TestCase
 
         $formatter = new AccessLogFormatter($format);
 
-        $message = $formatter->format($dataMap->reveal());
+        $message = $formatter->format($dataMap);
 
         $this->assertEquals($expected, $message);
     }

--- a/test/Log/SwooleLoggerFactoryTest.php
+++ b/test/Log/SwooleLoggerFactoryTest.php
@@ -52,7 +52,7 @@ class SwooleLoggerFactoryTest extends TestCase
      */
     public function testReturnsPsrLoggerWhenNoNamedLoggerIsFound(?array $config)
     {
-        $logger = (new SwooleLoggerFactory())($this->createContainerMockWithConfigAndPsrLogger($config));
+        $logger = (new SwooleLoggerFactory())($this->createContainerMockWithConfigAndPsrLogger([], $config));
         $this->assertSame($this->logger, $logger);
     }
 
@@ -61,7 +61,7 @@ class SwooleLoggerFactoryTest extends TestCase
      */
     public function testReturnsStdoutLoggerWhenOtherLoggersAreNotFound(?array $config)
     {
-        $logger = (new SwooleLoggerFactory())($this->createContainerMockWithConfigAndNotPsrLogger($config));
+        $logger = (new SwooleLoggerFactory())($this->createContainerMockWithConfigAndNotPsrLogger([], $config));
         $this->assertInstanceOf(StdoutLogger::class, $logger);
     }
 }

--- a/test/PidManagerFactoryTest.php
+++ b/test/PidManagerFactoryTest.php
@@ -19,14 +19,14 @@ class PidManagerFactoryTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->container         = $this->prophesize(ContainerInterface::class);
+        $this->container         = $this->createMock(ContainerInterface::class);
         $this->pidManagerFactory = new PidManagerFactory();
     }
 
     public function testFactoryReturnsAPidManager()
     {
         $factory    = $this->pidManagerFactory;
-        $pidManager = $factory($this->container->reveal());
+        $pidManager = $factory($this->container);
         $this->assertInstanceOf(PidManager::class, $pidManager);
     }
 }

--- a/test/ServerRequestSwooleFactoryTest.php
+++ b/test/ServerRequestSwooleFactoryTest.php
@@ -29,11 +29,6 @@ use const UPLOAD_ERR_OK;
 
 class ServerRequestSwooleFactoryTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $this->container = $this->prophesize(ContainerInterface::class);
-    }
-
     public function testConstructor()
     {
         $factory = new ServerRequestSwooleFactory();
@@ -86,7 +81,7 @@ class ServerRequestSwooleFactoryTest extends TestCase
 
         $factory = new ServerRequestSwooleFactory();
 
-        $result = $factory($this->container->reveal());
+        $result = $factory($this->createMock(ContainerInterface::class));
 
         $this->assertTrue(is_callable($result));
 

--- a/test/StaticResourceHandler/CacheControlMiddlewareTest.php
+++ b/test/StaticResourceHandler/CacheControlMiddlewareTest.php
@@ -66,7 +66,7 @@ class CacheControlMiddlewareTest extends TestCase
             ],
         ]);
 
-        $request         = $this->prophesize(Request::class)->reveal();
+        $request         = $this->createMock(Request::class);
         $request->server = [
             'request_uri' => '/some/path.html',
         ];
@@ -91,7 +91,7 @@ class CacheControlMiddlewareTest extends TestCase
             ],
         ]);
 
-        $request         = $this->prophesize(Request::class)->reveal();
+        $request         = $this->createMock(Request::class);
         $request->server = [
             'request_uri' => '/some/path.txt',
         ];

--- a/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
+++ b/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
@@ -24,7 +24,7 @@ class ContentTypeFilterMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->request = $this->prophesize(Request::class)->reveal();
+        $this->request = $this->createMock(Request::class);
     }
 
     public function testPassingNoArgumentsToConstructorSetsDefaultTypeMap()

--- a/test/StaticResourceHandler/ETagMiddlewareTest.php
+++ b/test/StaticResourceHandler/ETagMiddlewareTest.php
@@ -33,7 +33,7 @@ class ETagMiddlewareTest extends TestCase
         $this->next    = static function ($request, $filename) {
             return new StaticResourceResponse();
         };
-        $this->request = $this->prophesize(Request::class)->reveal();
+        $this->request = $this->createMock(Request::class);
     }
 
     public function testConstructorRaisesExceptionForInvalidRegexInDirectiveList()

--- a/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
+++ b/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
@@ -26,14 +26,14 @@ class FileLocationRepositoryFactoryTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->mockContainer      = $this->prophesize(ContainerInterface::class);
+        $this->mockContainer      = $this->createMock(ContainerInterface::class);
         $this->fileLocRepoFactory = new FileLocationRepositoryFactory();
         $this->assetDir           = __DIR__ . '/../TestAsset';
     }
 
     public function testFactoryReturnsFileLocationRepository()
     {
-        $this->mockContainer->get('config')->willReturn([
+        $this->mockContainer->method('get')->with('config')->willReturn([
             'mezzio-swoole' => [
                 'swoole-http-server' => [
                     'static-files' => [
@@ -43,13 +43,13 @@ class FileLocationRepositoryFactoryTest extends TestCase
             ],
         ]);
         $factory     = $this->fileLocRepoFactory;
-        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $fileLocRepo = $factory($this->mockContainer);
         $this->assertInstanceOf(FileLocationRepository::class, $fileLocRepo);
     }
 
     public function testFactoryUsesConfiguredDocumentRootArray()
     {
-        $this->mockContainer->get('config')->willReturn([
+        $this->mockContainer->method('get')->with('config')->willReturn([
             'mezzio-swoole' => [
                 'swoole-http-server' => [
                     'static-files' => [
@@ -59,13 +59,13 @@ class FileLocationRepositoryFactoryTest extends TestCase
             ],
         ]);
         $factory     = $this->fileLocRepoFactory;
-        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $fileLocRepo = $factory($this->mockContainer);
         $this->assertEquals(['/' => [$this->assetDir . '/']], $fileLocRepo->listMappedDocumentRoots());
     }
 
     public function testFactoryUsesConfiguredMappedDocumentRootsArray()
     {
-        $this->mockContainer->get('config')->willReturn([
+        $this->mockContainer->method('get')->with('config')->willReturn([
             'mezzio-swoole' => [
                 'swoole-http-server' => [
                     'static-files' => [
@@ -78,13 +78,13 @@ class FileLocationRepositoryFactoryTest extends TestCase
             ],
         ]);
         $factory     = $this->fileLocRepoFactory;
-        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $fileLocRepo = $factory($this->mockContainer);
         $this->assertEquals(['/foo/' => [$this->assetDir . '/']], $fileLocRepo->listMappedDocumentRoots());
     }
 
     public function testFactoryUsesConfiguredMappedDocumentRootString()
     {
-        $this->mockContainer->get('config')->willReturn([
+        $this->mockContainer->method('get')->with('config')->willReturn([
             'mezzio-swoole' => [
                 'swoole-http-server' => [
                     'static-files' => [
@@ -97,14 +97,14 @@ class FileLocationRepositoryFactoryTest extends TestCase
             ],
         ]);
         $factory     = $this->fileLocRepoFactory;
-        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $fileLocRepo = $factory($this->mockContainer);
 
         $this->assertEquals(['/foo/' => [$this->assetDir . '/']], $fileLocRepo->listMappedDocumentRoots());
     }
 
     public function testFactoryUsesBothConfiguredRootAndMappedDocumentRootString()
     {
-        $this->mockContainer->get('config')->willReturn([
+        $this->mockContainer->method('get')->with('config')->willReturn([
             'mezzio-swoole' => [
                 'swoole-http-server' => [
                     'static-files' => [
@@ -117,7 +117,7 @@ class FileLocationRepositoryFactoryTest extends TestCase
             ],
         ]);
         $factory     = $this->fileLocRepoFactory;
-        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $fileLocRepo = $factory($this->mockContainer);
 
         $this->assertEquals(
             ['/' => [__DIR__ . '/'], '/foo/' => [$this->assetDir . '/']],
@@ -127,7 +127,7 @@ class FileLocationRepositoryFactoryTest extends TestCase
 
     public function testFactoryUsesConfiguredDocumentRootString()
     {
-        $this->mockContainer->get('config')->willReturn([
+        $this->mockContainer->method('get')->with('config')->willReturn([
             'mezzio-swoole' => [
                 'swoole-http-server' => [
                     'static-files' => [
@@ -137,14 +137,14 @@ class FileLocationRepositoryFactoryTest extends TestCase
             ],
         ]);
         $factory     = $this->fileLocRepoFactory;
-        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $fileLocRepo = $factory($this->mockContainer);
 
         $this->assertEquals(['/' => [$this->assetDir . '/']], $fileLocRepo->listMappedDocumentRoots());
     }
 
     public function testFactoryHasNoDefaultsIfEmptyDocumentRoot()
     {
-        $this->mockContainer->get('config')->willReturn([
+        $this->mockContainer->method('get')->with('config')->willReturn([
             'mezzio-swoole' => [
                 'swoole-http-server' => [
                     'static-files' => [
@@ -154,7 +154,7 @@ class FileLocationRepositoryFactoryTest extends TestCase
             ],
         ]);
         $factory     = $this->fileLocRepoFactory;
-        $fileLocRepo = $factory($this->mockContainer->reveal());
+        $fileLocRepo = $factory($this->mockContainer);
         $this->assertEquals([], $fileLocRepo->listMappedDocumentRoots());
     }
 
@@ -172,7 +172,7 @@ class FileLocationRepositoryFactoryTest extends TestCase
             mkdir($tmpDir1);
             mkdir($tmpDir2);
             chdir($tmpDir1);
-            $this->mockContainer->get('config')->willReturn([
+            $this->mockContainer->method('get')->with('config')->willReturn([
                 'mezzio-swoole' => [
                     'swoole-http-server' => [
                         'static-files' => [],
@@ -180,7 +180,7 @@ class FileLocationRepositoryFactoryTest extends TestCase
                 ],
             ]);
             $factory     = $this->fileLocRepoFactory;
-            $fileLocRepo = $factory($this->mockContainer->reveal());
+            $fileLocRepo = $factory($this->mockContainer);
             $this->assertEquals(['/' => [$tmpDir2 . '/']], $fileLocRepo->listMappedDocumentRoots());
         } finally {
             rmdir($tmpDir2);

--- a/test/StaticResourceHandler/FileLocationRepositoryTest.php
+++ b/test/StaticResourceHandler/FileLocationRepositoryTest.php
@@ -13,7 +13,6 @@ namespace MezzioTest\Swoole;
 use Exception;
 use Mezzio\Swoole\StaticResourceHandler\FileLocationRepository;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 
 use function chdir;
 use function getcwd;
@@ -27,7 +26,6 @@ class FileLocationRepositoryTest extends TestCase
 {
     protected function setUp(): void
     {
-        $this->container   = $this->prophesize(ContainerInterface::class);
         $this->testDir     = __DIR__;
         $this->testValDir  = __DIR__ . '/';
         $this->fileLocRepo = new FileLocationRepository(['/' => $this->testValDir]);

--- a/test/StaticResourceHandler/HeadMiddlewareTest.php
+++ b/test/StaticResourceHandler/HeadMiddlewareTest.php
@@ -25,7 +25,7 @@ class HeadMiddlewareTest extends TestCase
         $this->next    = static function ($request, $filename) {
             return new StaticResourceResponse();
         };
-        $this->request = $this->prophesize(Request::class)->reveal();
+        $this->request = $this->createMock(Request::class);
     }
 
     public function nonHeadMethods(): array

--- a/test/StaticResourceHandler/LastModifiedMiddlewareTest.php
+++ b/test/StaticResourceHandler/LastModifiedMiddlewareTest.php
@@ -30,7 +30,7 @@ class LastModifiedMiddlewareTest extends TestCase
         $this->next    = static function ($request, $filename) {
             return new StaticResourceResponse();
         };
-        $this->request = $this->prophesize(Request::class)->reveal();
+        $this->request = $this->createMock(Request::class);
     }
 
     public function testConstructorRaisesExceptionForInvalidRegexInDirectiveList()

--- a/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php
+++ b/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php
@@ -22,7 +22,7 @@ class MethodNotAllowedMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->request = $this->prophesize(Request::class)->reveal();
+        $this->request = $this->createMock(Request::class);
     }
 
     public function alwaysAllowedMethods(): array

--- a/test/StaticResourceHandler/OptionsMiddlewareTest.php
+++ b/test/StaticResourceHandler/OptionsMiddlewareTest.php
@@ -22,7 +22,7 @@ class OptionsMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->request = $this->prophesize(Request::class)->reveal();
+        $this->request = $this->createMock(Request::class);
     }
 
     public function nonOptionsRequests(): array

--- a/test/StaticResourceHandler/StaticResourceResponseTest.php
+++ b/test/StaticResourceHandler/StaticResourceResponseTest.php
@@ -19,8 +19,18 @@ class StaticResourceResponseTest extends TestCase
     public function testSendSwooleResponsePopulatesStatusAndHeadersAndCallsContentCallback()
     {
         $expectedFilename = '/image.png';
-        $swooleResponse   = $this->prophesize(SwooleResponse::class);
-        $response         = new StaticResourceResponse();
+
+        $swooleResponse = $this->createMock(SwooleResponse::class);
+        $swooleResponse->expects($this->once())->method('status')->with(302);
+        $swooleResponse
+            ->expects($this->exactly(2))
+            ->method('header')
+            ->withConsecutive(
+                ['Location', 'https://example.com', true],
+                ['Expires', '3600', true]
+            );
+
+        $response = new StaticResourceResponse();
         $response->setStatus(302);
         $response->addHeader('Location', 'https://example.com');
         $response->addHeader('Expires', '3600');
@@ -29,18 +39,24 @@ class StaticResourceResponseTest extends TestCase
             TestCase::assertSame($expectedFilename, $filename);
         });
 
-        $this->assertNull($response->sendSwooleResponse($swooleResponse->reveal(), $expectedFilename));
-
-        $swooleResponse->status(302)->shouldHaveBeenCalled();
-        $swooleResponse->header('Location', 'https://example.com', true)->shouldHaveBeenCalled();
-        $swooleResponse->header('Expires', '3600', true)->shouldHaveBeenCalled();
+        $this->assertNull($response->sendSwooleResponse($swooleResponse, $expectedFilename));
     }
 
     public function testSendSwooleResponseSkipsSendingContentWhenContentDisabled()
     {
-        $filename       = '/image.png';
-        $swooleResponse = $this->prophesize(SwooleResponse::class);
-        $response       = new StaticResourceResponse();
+        $filename = '/image.png';
+
+        $swooleResponse = $this->createMock(SwooleResponse::class);
+        $swooleResponse->expects($this->once())->method('status')->with(302);
+        $swooleResponse
+            ->expects($this->exactly(2))
+            ->method('header')
+            ->withConsecutive(
+                ['Location', 'https://example.com', true],
+                ['Expires', '3600', true]
+            );
+
+        $response = new StaticResourceResponse();
         $response->setStatus(302);
         $response->addHeader('Location', 'https://example.com');
         $response->addHeader('Expires', '3600');
@@ -49,10 +65,6 @@ class StaticResourceResponseTest extends TestCase
         });
         $response->disableContent();
 
-        $this->assertNull($response->sendSwooleResponse($swooleResponse->reveal(), $filename));
-
-        $swooleResponse->status(302)->shouldHaveBeenCalled();
-        $swooleResponse->header('Location', 'https://example.com', true)->shouldHaveBeenCalled();
-        $swooleResponse->header('Expires', '3600', true)->shouldHaveBeenCalled();
+        $this->assertNull($response->sendSwooleResponse($swooleResponse, $filename));
     }
 }

--- a/test/StaticResourceHandlerFactoryTest.php
+++ b/test/StaticResourceHandlerFactoryTest.php
@@ -25,7 +25,7 @@ class StaticResourceHandlerFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container = $this->createMock(ContainerInterface::class);
     }
 
     public function assertHasMiddlewareOfType(string $type, array $middlewareList)
@@ -81,11 +81,11 @@ class StaticResourceHandlerFactoryTest extends TestCase
             ],
         ];
 
-        $this->container->get('config')->willReturn($config);
+        $this->container->method('get')->with('config')->willReturn($config);
 
         $factory = new StaticResourceHandlerFactory();
 
-        $handler = $factory($this->container->reveal());
+        $handler = $factory($this->container);
 
         $this->assertAttributeSame(
             $config['mezzio-swoole']['swoole-http-server']['static-files']['document-root'],

--- a/test/StaticResourceHandlerTest.php
+++ b/test/StaticResourceHandlerTest.php
@@ -23,8 +23,8 @@ class StaticResourceHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->docRoot  = __DIR__ . '/TestAsset';
-        $this->request  = $this->prophesize(SwooleHttpRequest::class)->reveal();
-        $this->response = $this->prophesize(SwooleHttpResponse::class)->reveal();
+        $this->request  = $this->createMock(SwooleHttpRequest::class);
+        $this->response = $this->createMock(SwooleHttpResponse::class);
     }
 
     public function testConstructorRaisesExceptionForInvalidMiddlewareValue()
@@ -63,11 +63,11 @@ class StaticResourceHandlerTest extends TestCase
             'request_uri' => '/image.png',
         ];
 
-        $expectedResponse = $this->prophesize(StaticResourceResponse::class);
-        $expectedResponse->isFailure()->willReturn(false);
-        $expectedResponse->sendSwooleResponse($this->response, $filename)->shouldBeCalled();
+        $expectedResponse = $this->createMock(StaticResourceResponse::class);
+        $expectedResponse->method('isFailure')->willReturn(false);
+        $expectedResponse->expects($this->once())->method('sendSwooleResponse')->with($this->response, $filename);
 
-        $middleware = new class ($expectedResponse->reveal()) implements MiddlewareInterface {
+        $middleware = new class ($expectedResponse) implements MiddlewareInterface {
             private $response;
 
             public function __construct(StaticResourceResponse $response)
@@ -87,7 +87,7 @@ class StaticResourceHandlerTest extends TestCase
         $handler = new StaticResourceHandler($this->docRoot, [$middleware]);
 
         $this->assertSame(
-            $expectedResponse->reveal(),
+            $expectedResponse,
             $handler->processStaticResource($this->request, $this->response)
         );
     }

--- a/test/SwooleRequestHandlerRunnerFactoryTest.php
+++ b/test/SwooleRequestHandlerRunnerFactoryTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 
 namespace MezzioTest\Swoole;
 
+use Laminas\Stdlib\ArrayUtils;
 use Mezzio\ApplicationPipeline;
 use Mezzio\Response\ServerRequestErrorResponseGenerator;
 use Mezzio\Swoole\HotCodeReload\Reloader;
 use Mezzio\Swoole\Log\AccessLogInterface;
 use Mezzio\Swoole\Log\Psr3AccessLogDecorator;
 use Mezzio\Swoole\PidManager;
-use Mezzio\Swoole\ServerFactory;
 use Mezzio\Swoole\StaticResourceHandlerInterface;
 use Mezzio\Swoole\SwooleRequestHandlerRunner;
 use Mezzio\Swoole\SwooleRequestHandlerRunnerFactory;
@@ -33,113 +33,100 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->applicationPipeline = $this->prophesize(ApplicationPipeline::class);
-        $this->applicationPipeline->willImplement(RequestHandlerInterface::class);
+        $this->applicationPipeline = $this->createMock(RequestHandlerInterface::class);
 
-        $this->serverRequest = $this->prophesize(ServerRequestInterface::class);
+        $this->serverRequest = $this->createMock(ServerRequestInterface::class);
 
-        $this->serverRequestError = $this->prophesize(ServerRequestErrorResponseGenerator::class);
-        $this->serverFactory      = $this->prophesize(ServerFactory::class);
-        $this->pidManager         = $this->prophesize(PidManager::class);
+        $this->serverRequestError = $this->createMock(ServerRequestErrorResponseGenerator::class);
+        $this->pidManager         = $this->createMock(PidManager::class);
 
-        $this->staticResourceHandler = $this->prophesize(StaticResourceHandlerInterface::class);
-        $this->logger                = $this->prophesize(AccessLogInterface::class);
-        $this->hotCodeReloader       = $this->prophesize(Reloader::class);
+        $this->staticResourceHandler = $this->createMock(StaticResourceHandlerInterface::class);
+        $this->logger                = $this->createMock(AccessLogInterface::class);
+        $this->hotCodeReloader       = $this->createMock(Reloader::class);
 
-        $this->container = $this->prophesize(ContainerInterface::class);
-        $this->container
-            ->get(ApplicationPipeline::class)
-            ->will([$this->applicationPipeline, 'reveal']);
-        $this->container
-            ->get(ServerRequestInterface::class)
-            ->willReturn(function () {
-                return $this->serverRequest->reveal();
-            });
-        $this->container
-            ->get(ServerRequestErrorResponseGenerator::class)
-            ->willReturn(function () {
-                $this->serverRequestError->reveal();
-            });
-        $this->container
-            ->get(PidManager::class)
-            ->will([$this->pidManager, 'reveal']);
-
-        $this->container
-            ->get(SwooleHttpServer::class)
-            ->willReturn($this->createMock(SwooleHttpServer::class));
+        $this->containerMap = [
+            'has' => [],
+            'get' => [
+                ApplicationPipeline::class                 => $this->applicationPipeline,
+                PidManager::class                          => $this->pidManager,
+                SwooleHttpServer::class                    => $this->createMock(SwooleHttpServer::class),
+                ServerRequestInterface::class              => function () {
+                    return $this->serverRequest;
+                },
+                ServerRequestErrorResponseGenerator::class => function () {
+                    $this->serverRequestError;
+                },
+            ],
+        ];
     }
 
-    public function configureAbsentStaticResourceHandler()
+    public function mockContainer(array $methodMap): ContainerInterface
     {
-        $this->container
-            ->has(StaticResourceHandlerInterface::class)
-            ->willReturn(false);
+        $container = $this->createMock(ContainerInterface::class);
+        foreach ($methodMap as $method => $serviceMap) {
+            $valueMap = [];
+            foreach ($serviceMap as $serviceName => $value) {
+                $valueMap[] = [$serviceName, $value];
+            }
+            $container->method($method)->will($this->returnValueMap($valueMap));
+        }
+        return $container;
+    }
 
-        $this->container
-            ->get(StaticResourceHandlerInterface::class)
-            ->shouldNotBeCalled();
-
-        $this->container
-            ->get('config')
-            ->willReturn([
-                'mezzio-swoole' => [
-                    'swoole-http-server' => [
-                        'static-files' => [],
+    public function configureAbsentStaticResourceHandler(array $baseConfig = []): array
+    {
+        return ArrayUtils::merge($baseConfig, [
+            'has' => [
+                StaticResourceHandlerInterface::class => false,
+            ],
+            'get' => [
+                'config' => [
+                    'mezzio-swoole' => [
+                        'swoole-http-server' => [
+                            'static-files' => [],
+                        ],
                     ],
                 ],
-            ]);
+            ],
+        ]);
     }
 
-    public function configureAbsentLoggerService()
+    public function configureAbsentLoggerService(array $baseConfig = []): array
     {
-        $this->container
-            ->has(AccessLogInterface::class)
-            ->willReturn(false);
-
-        $this->container
-            ->get(AccessLogInterface::class)
-            ->shouldNotBeCalled();
-
-        // Legacy Zend Framework class
-        $this->container
-            ->has(LegacyAccessLogInterface::class)
-            ->willReturn(false);
-
-        $this->container
-            ->get(LegacyAccessLogInterface::class)
-            ->shouldNotBeCalled();
+        return ArrayUtils::merge($baseConfig, [
+            'has' => [
+                AccessLogInterface::class       => false,
+                LegacyAccessLogInterface::class => false,
+            ],
+        ]);
     }
 
-    public function configureAbsentConfiguration(): void
+    public function configureAbsentConfiguration(array $baseConfig = []): array
     {
-        $this->container
-            ->has('config')
-            ->willReturn(false);
-
-        $this->container
-            ->get('config')
-            ->shouldNotBeCalled();
+        return ArrayUtils::merge($baseConfig, [
+            'has' => [
+                'config' => false,
+            ],
+        ]);
     }
 
-    public function configureAbsentHotCodeReloader(): void
+    public function configureAbsentHotCodeReloader(array $baseConfig = []): array
     {
-        $this->container
-            ->has(Reloader::class)
-            ->willReturn(false);
-
-        $this->container
-            ->get(Reloader::class)
-            ->shouldNotBeCalled();
+        return ArrayUtils::merge($baseConfig, [
+            'has' => [
+                Reloader::class => false,
+            ],
+        ]);
     }
 
     public function testInvocationWithoutOptionalServicesConfiguresInstanceWithDefaults()
     {
-        $this->configureAbsentStaticResourceHandler();
-        $this->configureAbsentLoggerService();
-        $this->configureAbsentConfiguration();
-        $this->configureAbsentHotCodeReloader();
-        $factory = new SwooleRequestHandlerRunnerFactory();
-        $runner  = $factory($this->container->reveal());
+        $containerMap = $this->configureAbsentStaticResourceHandler($this->containerMap);
+        $containerMap = $this->configureAbsentLoggerService($containerMap);
+        $containerMap = $this->configureAbsentConfiguration($containerMap);
+        $containerMap = $this->configureAbsentHotCodeReloader($containerMap);
+        $factory      = new SwooleRequestHandlerRunnerFactory();
+        $runner       = $factory($this->mockContainer($containerMap));
         $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
         $this->assertAttributeEmpty('staticResourceHandler', $runner);
         $this->assertAttributeInstanceOf(Psr3AccessLogDecorator::class, 'logger', $runner);
@@ -147,79 +134,65 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
 
     public function testFactoryWillUseConfiguredPsr3LoggerWhenPresent()
     {
-        $this->configureAbsentStaticResourceHandler();
-        $this->configureAbsentConfiguration();
-        $this->configureAbsentHotCodeReloader();
-        $this->container
-            ->has(AccessLogInterface::class)
-            ->willReturn(true);
-        $this->container
-            ->get(AccessLogInterface::class)
-            ->will([$this->logger, 'reveal']);
+        $containerMap = $this->configureAbsentStaticResourceHandler($this->containerMap);
+        $containerMap = $this->configureAbsentStaticResourceHandler($containerMap);
+        $containerMap = $this->configureAbsentConfiguration($containerMap);
+        $containerMap = $this->configureAbsentHotCodeReloader($containerMap);
+
+        $containerMap['has'][AccessLogInterface::class] = true;
+        $containerMap['get'][AccessLogInterface::class] = $this->logger;
 
         $factory = new SwooleRequestHandlerRunnerFactory();
-        $runner  = $factory($this->container->reveal());
+        $runner  = $factory($this->mockContainer($containerMap));
         $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
-        $this->assertAttributeSame($this->logger->reveal(), 'logger', $runner);
+        $this->assertAttributeSame($this->logger, 'logger', $runner);
     }
 
     public function testFactoryWillUseConfiguredStaticResourceHandlerWhenPresent(): SwooleRequestHandlerRunner
     {
-        $this->configureAbsentLoggerService();
-        $this->configureAbsentHotCodeReloader();
-        $this->container
-            ->has(StaticResourceHandlerInterface::class)
-            ->willReturn(true);
-        $this->container
-            ->get(StaticResourceHandlerInterface::class)
-            ->will([$this->staticResourceHandler, 'reveal']);
-        $this->container->has('config')->willReturn(true);
-        $this->container
-            ->get('config')
-            ->willReturn([
-                'mezzio-swoole' => [
-                    'swoole-http-server' => [
-                        'static-files' => [
-                            'enable' => true,
-                        ],
+        $containerMap                                               = $this->configureAbsentLoggerService($this->containerMap);
+        $containerMap                                               = $this->configureAbsentHotCodeReloader($containerMap);
+        $containerMap['has'][StaticResourceHandlerInterface::class] = true;
+        $containerMap['get'][StaticResourceHandlerInterface::class] = $this->staticResourceHandler;
+        $containerMap['has']['config']                              = true;
+        $containerMap['get']['config']                              = [
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'enable' => true,
                     ],
                 ],
-            ]);
+            ],
+        ];
 
         $factory = new SwooleRequestHandlerRunnerFactory();
-        $runner  = $factory($this->container->reveal());
+        $runner  = $factory($this->mockContainer($containerMap));
         $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
-        $this->assertAttributeSame($this->staticResourceHandler->reveal(), 'staticResourceHandler', $runner);
+        $this->assertAttributeSame($this->staticResourceHandler, 'staticResourceHandler', $runner);
 
         return $runner;
     }
 
     public function testFactoryWillIgnoreConfiguredStaticResourceHandlerWhenStaticFilesAreDisabled()
     {
-        $this->configureAbsentLoggerService();
-        $this->configureAbsentHotCodeReloader();
-        $this->container
-            ->has(StaticResourceHandlerInterface::class)
-            ->willReturn(true);
-        $this->container->has('config')->willReturn(true);
-        $this->container
-            ->get('config')
-            ->willReturn([
-                'mezzio-swoole' => [
-                    'swoole-http-server' => [
-                        'static-files' => [
-                            'enable' => false, // Disabling static files
-                        ],
+        $containerMap = $this->configureAbsentLoggerService($this->containerMap);
+        $containerMap = $this->configureAbsentHotCodeReloader($containerMap);
+
+        $containerMap['has'][StaticResourceHandlerInterface::class] = true;
+        $containerMap['has']['config']                              = true;
+        $containerMap['get']['config']                              = [
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'static-files' => [
+                        'enable' => false, // Disabling static files
                     ],
                 ],
-            ]);
+            ],
+        ];
 
         $factory = new SwooleRequestHandlerRunnerFactory();
-        $runner  = $factory($this->container->reveal());
+        $runner  = $factory($this->mockContainer($containerMap));
 
-        $this->container
-            ->get(StaticResourceHandlerInterface::class)
-            ->shouldNotHaveBeenCalled();
         $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
         $this->assertAttributeEmpty('staticResourceHandler', $runner);
     }
@@ -234,24 +207,21 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
 
     public function testFactoryUsesConfiguredProcessNameWhenPresent()
     {
-        $this->configureAbsentLoggerService();
-        $this->configureAbsentHotCodeReloader();
-        $this->container
-            ->has(StaticResourceHandlerInterface::class)
-            ->willReturn(false);
-        $this->container->has('config')->willReturn(true);
-        $this->container
-            ->get('config')
-            ->willReturn([
-                'mezzio-swoole' => [
-                    'swoole-http-server' => [
-                        'process-name' => 'mezzio-swoole-test',
-                    ],
+        $containerMap = $this->configureAbsentLoggerService($this->containerMap);
+        $containerMap = $this->configureAbsentHotCodeReloader($containerMap);
+
+        $containerMap['has'][StaticResourceHandlerInterface::class] = false;
+        $containerMap['has']['config']                              = true;
+        $containerMap['get']['config']                              = [
+            'mezzio-swoole' => [
+                'swoole-http-server' => [
+                    'process-name' => 'mezzio-swoole-test',
                 ],
-            ]);
+            ],
+        ];
 
         $factory = new SwooleRequestHandlerRunnerFactory();
-        $runner  = $factory($this->container->reveal());
+        $runner  = $factory($this->mockContainer($containerMap));
 
         $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
         $this->assertAttributeSame('mezzio-swoole-test', 'processName', $runner);
@@ -259,26 +229,22 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
 
     public function testFactoryWillUseConfiguredHotCodeReloaderWhenPresent()
     {
-        $this->configureAbsentLoggerService();
-        $this->container->has(Reloader::class)->willReturn(true);
-        $this->container
-            ->get(Reloader::class)
-            ->will([$this->hotCodeReloader, 'reveal']);
-        $this->container->has('config')->willReturn(true);
-        $this->container
-            ->get('config')
-            ->willReturn([
-                'mezzio-swoole' => [
-                    'hot-code-reload' => [
-                        'enable' => true,
-                    ],
+        $containerMap                         = $this->configureAbsentLoggerService($this->containerMap);
+        $containerMap['has'][Reloader::class] = true;
+        $containerMap['has']['config']        = true;
+        $containerMap['get'][Reloader::class] = $this->hotCodeReloader;
+        $containerMap['get']['config']        = [
+            'mezzio-swoole' => [
+                'hot-code-reload' => [
+                    'enable' => true,
                 ],
-            ]);
+            ],
+        ];
 
         $factory = new SwooleRequestHandlerRunnerFactory();
-        $runner  = $factory($this->container->reveal());
+        $runner  = $factory($this->mockContainer($containerMap));
 
         $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
-        $this->assertAttributeSame($this->hotCodeReloader->reveal(), 'hotCodeReloader', $runner);
+        $this->assertAttributeSame($this->hotCodeReloader, 'hotCodeReloader', $runner);
     }
 }

--- a/test/SwooleStreamTest.php
+++ b/test/SwooleStreamTest.php
@@ -32,12 +32,12 @@ class SwooleStreamTest extends TestCase
         if (! extension_loaded('swoole')) {
             $this->markTestSkipped('The Swoole extension is not available');
         }
-        $this->request = $this->prophesize(SwooleHttpRequest::class);
+        $this->request = $this->createMock(SwooleHttpRequest::class);
         $this->request
-            ->rawContent()
+            ->method('rawContent')
             ->willReturn(self::DEFAULT_CONTENT);
 
-        $this->stream = new SwooleStream($this->request->reveal());
+        $this->stream = new SwooleStream($this->request);
     }
 
     public function testEofWhenOneCharacterLeftCase(): void
@@ -53,12 +53,12 @@ class SwooleStreamTest extends TestCase
 
     public function testGetContentsWithNoRawContent()
     {
-        $request = $this->prophesize(SwooleHttpRequest::class);
+        $request = $this->createMock(SwooleHttpRequest::class);
         $request
-            ->rawContent()
+            ->method('rawContent')
             ->willReturn(false);
 
-        $stream = new SwooleStream($request->reveal());
+        $stream = new SwooleStream($request);
 
         $this->assertEquals('', $stream->getContents());
     }
@@ -82,10 +82,11 @@ class SwooleStreamTest extends TestCase
 
     public function testGetContentsWithEmptyBodyReturnsEmptyString()
     {
-        $this->request
-            ->rawContent()
+        $request = $this->createMock(SwooleHttpRequest::class);
+        $request
+            ->method('rawContent')
             ->willReturn('');
-        $this->stream = new SwooleStream($this->request->reveal());
+        $this->stream = new SwooleStream($request);
 
         $this->assertEquals('', $this->stream->getContents());
     }
@@ -111,10 +112,11 @@ class SwooleStreamTest extends TestCase
 
     public function testGetSizeWithEmptyBodyReturnsZero()
     {
-        $this->request
-            ->rawContent()
+        $request = $this->createMock(SwooleHttpRequest::class);
+        $request
+            ->method('rawContent')
             ->willReturn('');
-        $this->stream = new SwooleStream($this->request->reveal());
+        $this->stream = new SwooleStream($request);
 
         $this->assertEquals(0, $this->stream->getSize());
     }
@@ -218,7 +220,7 @@ class SwooleStreamTest extends TestCase
 
     public function testDetachReturnsRequestInstance()
     {
-        $this->assertSame($this->request->reveal(), $this->stream->detach());
+        $this->assertSame($this->request, $this->stream->detach());
     }
 
     public function testCloseReturnsNull()


### PR DESCRIPTION
- Adds `~8.0.0` to the list of PHP constraints
- Bumps the minimum supported PHP version to 7.3
- Bumps the minimum supported PHPUnit version to 9.3
- Adds PHP nightly jobs to the Travis job matrix
- Migrates tests from Prophecy to PHPUnit native mock objects

Fixes #30
