### PR TITLE
Allow the start and reload commands to specify the number of task workers to spawn

### DIFF
--- a/docs/book/v3/async-tasks.md
+++ b/docs/book/v3/async-tasks.md
@@ -29,11 +29,12 @@ Tasks are queued in the order that they trigger, meaning that a `task_worker_num
 ];
 ```
 
-> ### No CLI option for task_worker_num
+> ### CLI options for worker_num and task_worker_num
 >
-> Unlike `worker_num`, there is no CLI option for `task_worker_num`.
-> This is because enabling the task worker also requires registering a task worker with the server.
-> To prevent accidental startup failures due to passing an option to specify the number of task workers without having registered a task worker, we omitted the CLI option.
+> Each of the `worker_num` and `task_worker_num` options have corresponding options in the `mezzio:swoole:start` and `mezzio:swoole:reload` console commands:
+>
+> - `--num-workers|-w` can be used to specify the number of HTTP Server Workers
+> - `--num-task-workers|-t` can be used to specify the number of Task Workers
 
 ## Task Events
 

--- a/docs/book/v3/command-line.md
+++ b/docs/book/v3/command-line.md
@@ -20,7 +20,7 @@ The `mezzio:swoole:start` command, however, may need customizations if you have 
 
 The `mezzio:swoole:start` command will start the web server using the following steps:
 
-- It pulls the `Swoole\Http\Server` service from the application dependency injection container, and calls `set()` on it with options denoting the number of workers to run (provided via the `--num-workers` or `-w` option), and whether or not to daemonize the server (provided via the `--daemonize` or `-d` option).
+- It pulls the `Swoole\Http\Server` service from the application dependency injection container, and calls `set()` on it with options denoting the number of workers to run (provided via the `--num-workers` or `-w` option), the number of task workers to spawn (provided via the `--num-task-workers` or `-t` option), and whether or not to daemonize the server (provided via the `--daemonize` or `-d` option).
 
 - It pulls the `Mezzio\Application` and `Mezzio\MiddlewareFactory` services from the container.
 

--- a/docs/book/v3/migration.md
+++ b/docs/book/v3/migration.md
@@ -43,6 +43,16 @@ Use the [HotCodeReloaderWorkerStartListener](hot-code-reload.md) instead.
 Additionally, with version 3, you will need to specify which paths you want to scan for changes via configuration.
 Please see the [hot code reloading section on Configuration](hot-code-reload.md#configuration) for details.
 
+## Tasks
+
+In version 2 of this package, if you wanted to use the Swoole HTTP Server task functionality, you needed to:
+
+- Set the `task_worker_num` option for the server instance in configuration.
+- Create and register a `task` event handler with the server instance.
+
+With version 3 of this package, we now always register a `task` event handler (see the [Swoole HTTP Server Events](events.md) and [Triggering Async Tasks](async-tasks.md) chapters for details), which means you only need to configure the `task_worker_num` setting.
+Alternately, you can pass the `--num-task-workers|-t` option with a numeric number of task workers to either of the `mezzio:swoole:start` or `mezzio:swoole:reload` console commands (see [Command line usage](#command-line-usage) section below for details).
+
 ## Command line usage
 
 In releases prior to version 3, the package shipped with its own binary, `mezzio-swoole`, and defined the commands `start`, `stop`, `status`, and `reload`.
@@ -61,3 +71,4 @@ $ ./vendor/bin/laminas mezzio:swoole:start
 ```
 
 Usage of other commands will change similarly.
+

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -53,6 +53,12 @@ EOH;
             InputOption::VALUE_REQUIRED,
             'Number of worker processes to use after reloading.'
         );
+        $this->addOption(
+            'num-task-workers',
+            't',
+            InputOption::VALUE_REQUIRED,
+            'Number of task worker processes to use.'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -87,12 +93,20 @@ EOH;
         $output->writeln('<info>[DONE]</info>');
         $output->writeln('<info>Starting server</info>');
 
-        $start  = $application->find('start');
-        $result = $start->run(new ArrayInput([
+        $start = $application->find('start');
+
+        $inputArguments = [
             'command'       => 'start',
             '--daemonize'   => true,
             '--num-workers' => $input->getOption('num-workers') ?? StartCommand::DEFAULT_NUM_WORKERS,
-        ]), $output);
+        ];
+
+        $numTaskWorkers = $input->getOption('num-task-workers');
+        if (null !== $numTaskWorkers) {
+            $inputArguments['--num-task-workers'] = $numTaskWorkers;
+        }
+
+        $result = $start->run(new ArrayInput($inputArguments), $output);
 
         if (0 !== $result) {
             $output->writeln('<error>Cannot reload server: unable to start server</error>');

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -70,6 +70,12 @@ EOH;
             InputOption::VALUE_REQUIRED,
             'Number of worker processes to use.'
         );
+        $this->addOption(
+            'num-task-workers',
+            't',
+            InputOption::VALUE_REQUIRED,
+            'Number of task worker processes to use.'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -80,14 +86,18 @@ EOH;
             return 1;
         }
 
-        $serverOptions = [];
-        $daemonize     = $input->getOption('daemonize');
-        $numWorkers    = $input->getOption('num-workers');
+        $serverOptions  = [];
+        $daemonize      = $input->getOption('daemonize');
+        $numWorkers     = $input->getOption('num-workers');
+        $numTaskWorkers = $input->getOption('num-task-workers');
         if ($daemonize) {
             $serverOptions['daemonize'] = $daemonize;
         }
         if (null !== $numWorkers) {
             $serverOptions['worker_num'] = $numWorkers;
+        }
+        if (null !== $numTaskWorkers) {
+            $serverOptions['task_worker_num'] = $numTaskWorkers;
         }
 
         if ([] !== $serverOptions) {

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -100,6 +100,31 @@ class ReloadCommandTest extends TestCase
         $this->assertSame('w', $option->getShortcut());
     }
 
+    /**
+     * @depends testConstructorAcceptsServerMode
+     */
+    public function testCommandDefinesNumTaskWorkersOption(ReloadCommand $command): InputOption
+    {
+        $this->assertTrue($command->getDefinition()->hasOption('num-task-workers'));
+        return $command->getDefinition()->getOption('num-task-workers');
+    }
+
+    /**
+     * @depends testCommandDefinesNumTaskWorkersOption
+     */
+    public function testNumTaskWorkersOptionIsRequired(InputOption $option): void
+    {
+        $this->assertTrue($option->isValueRequired());
+    }
+
+    /**
+     * @depends testCommandDefinesNumTaskWorkersOption
+     */
+    public function testNumTaskWorkersOptionDefinesShortOption(InputOption $option): void
+    {
+        $this->assertSame('t', $option->getShortcut());
+    }
+
     public function testExecuteEndsWithErrorWhenServerModeIsNotProcessMode(): void
     {
         $command = new ReloadCommand(SWOOLE_BASE);
@@ -149,7 +174,17 @@ class ReloadCommandTest extends TestCase
     {
         $command = new ReloadCommand(SWOOLE_PROCESS);
 
-        $this->input->method('getOption')->with('num-workers')->willReturn(5);
+        $this->input
+            ->expects($this->exactly(2))
+            ->method('getOption')
+            ->withConsecutive(
+                ['num-workers'],
+                ['num-task-workers']
+            )
+            ->willReturnOnConsecutiveCalls(
+                5,
+                null
+            );
 
         $stopCommand = $this->createMock(Command::class);
         $stopCommand
@@ -218,7 +253,17 @@ class ReloadCommandTest extends TestCase
     {
         $command = new ReloadCommand(SWOOLE_PROCESS);
 
-        $this->input->method('getOption')->with('num-workers')->willReturn(5);
+        $this->input
+            ->expects($this->exactly(2))
+            ->method('getOption')
+            ->withConsecutive(
+                ['num-workers'],
+                ['num-task-workers']
+            )
+            ->willReturnOnConsecutiveCalls(
+                5,
+                2
+            );
 
         $stopCommand = $this->createMock(Command::class);
         $stopCommand
@@ -236,7 +281,7 @@ class ReloadCommandTest extends TestCase
             ->method('run')
             ->with(
                 $this->callback(static function (ArrayInput $arg) {
-                    return 'start --daemonize=1 --num-workers=5' === (string) $arg;
+                    return 'start --daemonize=1 --num-workers=5 --num-task-workers=2' === (string) $arg;
                 }),
                 $this->output
             )

--- a/test/Command/StartCommandTest.php
+++ b/test/Command/StartCommandTest.php
@@ -129,6 +129,31 @@ class StartCommandTest extends TestCase
     /**
      * @depends testConstructorAcceptsContainer
      */
+    public function testCommandDefinesNumTaskWorkersOption(StartCommand $command): InputOption
+    {
+        $this->assertTrue($command->getDefinition()->hasOption('num-task-workers'));
+        return $command->getDefinition()->getOption('num-task-workers');
+    }
+
+    /**
+     * @depends testCommandDefinesNumTaskWorkersOption
+     */
+    public function testNumTaskWorkersOptionIsRequired(InputOption $option): void
+    {
+        $this->assertTrue($option->isValueRequired());
+    }
+
+    /**
+     * @depends testCommandDefinesNumTaskWorkersOption
+     */
+    public function testNumTaskWorkersOptionDefinesShortOption(InputOption $option): void
+    {
+        $this->assertSame('t', $option->getShortcut());
+    }
+
+    /**
+     * @depends testConstructorAcceptsContainer
+     */
     public function testCommandDefinesDaemonizeOption(StartCommand $command): InputOption
     {
         $this->assertTrue($command->getDefinition()->hasOption('daemonize'));
@@ -205,6 +230,7 @@ class StartCommandTest extends TestCase
             ->will($this->returnValueMap([
                 ['daemonize', true],
                 ['num-workers', 6],
+                ['num-task-workers', 4],
             ]));
 
         $this->pidManager->method('read')->willReturn($pids);
@@ -215,8 +241,10 @@ class StartCommandTest extends TestCase
             ->with($this->callback(static function (array $options) {
                 return array_key_exists('daemonize', $options)
                     && array_key_exists('worker_num', $options)
+                    && array_key_exists('task_worker_num', $options)
                     && true === $options['daemonize']
-                    && 6 === $options['worker_num'];
+                    && 6 === $options['worker_num']
+                    && 4 === $options['task_worker_num'];
             }));
 
         $application->expects($this->once())->method('run');
@@ -252,6 +280,7 @@ class StartCommandTest extends TestCase
             ->will($this->returnValueMap([
                 ['daemonize', false],
                 ['num-workers', null],
+                ['num-task-workers', null],
             ]));
 
         [$command, $httpServer, $application] = $this->prepareSuccessfulStartCommand($pids);


### PR DESCRIPTION
This patch introduces the option `--num-task-workers` (or `-t`) to each of the `StartCommand` and `ReloadCommand`.
The value defaults to `null`, indicating no task workers should be spawned (or to use the configuration setting).

(This can be done in the v3 series because we now **always** register a task event handler.)

Fixes #37
