### PR TITLE
Add property typehints

### DIFF
--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -34,8 +34,7 @@ EOH;
     /** @var string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:swoole:reload';
 
-    /** @var int */
-    private $serverMode;
+    private int $serverMode;
 
     public function __construct(int $serverMode)
     {

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -45,8 +45,7 @@ EOH;
     /** @var string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:swoole:start';
 
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     public function __construct(ContainerInterface $container)
     {

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -29,8 +29,7 @@ EOH;
     /** @var string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:swoole:status';
 
-    /** @var PidManager */
-    private $pidManager;
+    private PidManager $pidManager;
 
     public function __construct(PidManager $pidManager)
     {

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -44,15 +44,13 @@ EOH;
     public $killProcess;
 
     /**
-     * @internal
+     * How long to wait for the server process to end. Only change the value when testing.
      *
-     * @var int How long to wait for the server process to end. Only change
-     *     the value when testing.
+     * @internal
      */
-    public $waitThreshold = 60;
+    public int $waitThreshold = 60;
 
-    /** @var PidManager */
-    private $pidManager;
+    private PidManager $pidManager;
 
     public function __construct(PidManager $pidManager)
     {

--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -16,8 +16,7 @@ use Psr\EventDispatcher\StoppableEventInterface;
 
 class EventDispatcher implements EventDispatcherInterface
 {
-    /** @var ListenerProviderInterface */
-    private $listenerProvider;
+    private ListenerProviderInterface $listenerProvider;
 
     public function __construct(ListenerProviderInterface $listenerProvider)
     {

--- a/src/Event/HotCodeReloaderWorkerStartListener.php
+++ b/src/Event/HotCodeReloaderWorkerStartListener.php
@@ -17,16 +17,12 @@ class HotCodeReloaderWorkerStartListener
 {
     /**
      * A file watcher to monitor changes in files.
-     *
-     * @var FileWatcherInterface
      */
-    private $fileWatcher;
+    private FileWatcherInterface $fileWatcher;
 
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
-    /** @var int */
-    private $interval;
+    private int $interval;
 
     public function __construct(FileWatcherInterface $fileWatcher, LoggerInterface $logger, int $interval)
     {

--- a/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
+++ b/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
@@ -35,7 +35,7 @@ class InotifyFileWatcher implements FileWatcherInterface
     private $inotify;
 
     /** @var string[] */
-    private $filePathByWd = [];
+    private array $filePathByWd = [];
 
     public function __construct()
     {

--- a/src/Log/AccessLogDataMap.php
+++ b/src/Log/AccessLogDataMap.php
@@ -42,26 +42,20 @@ class AccessLogDataMap
 
     /**
      * Timestamp when created, indicating end of request processing.
-     *
-     * @var float
      */
-    private $endTime;
+    private float $endTime;
 
-    /** @var SwooleHttpRequest */
-    private $request;
+    private SwooleHttpRequest $request;
 
-    /** @var null|PsrResponse */
-    private $psrResponse;
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    private ?PsrResponse $psrResponse;
 
     /**
      * Whether or not to do a hostname lookup when retrieving the remote host name
-     *
-     * @var bool
      */
-    private $useHostnameLookups;
+    private bool $useHostnameLookups;
 
-    /** @var StaticResourceResponse */
-    private $staticResource;
+    private StaticResourceResponse $staticResource;
 
     public static function createWithPsrResponse(
         SwooleHttpRequest $request,

--- a/src/Log/AccessLogFormatter.php
+++ b/src/Log/AccessLogFormatter.php
@@ -31,21 +31,17 @@ class AccessLogFormatter implements AccessLogFormatterInterface
     /**
      * @link https://anonscm.debian.org/cgit/pkg-apache/apache2.git/tree/debian/config-dir/apache2.conf.in#n212
      *
-     * @codingStandardsIgnoreStart
      * phpcs:disable
      */
     public const FORMAT_COMMON_DEBIAN = '%h %l %u %t “%r” %>s %O';
     public const FORMAT_COMBINED_DEBIAN = '%h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i”';
     public const FORMAT_VHOST_COMBINED_DEBIAN = '%v:%p %h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i"';
-    // @codingStandardsIgnoreEnd
     // phpcs:enable
 
     /**
      * Message format to use when generating a log message.
-     *
-     * @var string
      */
-    private $format;
+    private string $format;
 
     public function __construct(string $format = self::FORMAT_COMMON)
     {

--- a/src/Log/Psr3AccessLogDecorator.php
+++ b/src/Log/Psr3AccessLogDecorator.php
@@ -17,19 +17,15 @@ use Swoole\Http\Request;
 
 class Psr3AccessLogDecorator implements AccessLogInterface
 {
-    /** @var AccessLogFormatter */
-    private $formatter;
+    private AccessLogFormatterInterface $formatter;
 
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
     /**
      * Whether or not to look up remote host names when preparing the access
      * log message
-     *
-     * @var bool
      */
-    private $useHostnameLookups;
+    private bool $useHostnameLookups;
 
     public function __construct(
         LoggerInterface $logger,

--- a/src/PidManager.php
+++ b/src/PidManager.php
@@ -21,8 +21,7 @@ use function unlink;
 
 class PidManager
 {
-    /** @var string */
-    private $pidFile = '';
+    private string $pidFile = '';
 
     public function __construct(string $pidFile)
     {

--- a/src/StaticMappedResourceHandler.php
+++ b/src/StaticMappedResourceHandler.php
@@ -23,14 +23,9 @@ class StaticMappedResourceHandler implements StaticResourceHandlerInterface
      *
      * @var StaticResourceHandler\MiddlewareInterface[]
      */
-    private $middleware;
+    private array $middleware;
 
-    /**
-     * Middleware to execute when serving a static resource.
-     *
-     * @var FileLocationRepositoryInterface[]
-     */
-    private $fileLocationRepo;
+    private FileLocationRepositoryInterface $fileLocationRepo;
 
     /**
      * @throws Exception\InvalidStaticResourceMiddlewareException For any
@@ -49,6 +44,7 @@ class StaticMappedResourceHandler implements StaticResourceHandlerInterface
         SwooleHttpRequest $request,
         SwooleHttpResponse $response
     ): ?StaticResourceHandler\StaticResourceResponse {
+        /** @psalm-suppress MixedArgument */
         $filename = $this->fileLocationRepo->findFile($request->server['request_uri']);
         if (! $filename) {
             return null;

--- a/src/StaticResourceHandler.php
+++ b/src/StaticResourceHandler.php
@@ -20,15 +20,14 @@ class StaticResourceHandler implements StaticResourceHandlerInterface
 {
     use StaticResourceHandler\ValidateMiddlewareTrait;
 
-    /** @var string */
-    private $docRoot;
+    private string $docRoot;
 
     /**
      * Middleware to execute when serving a static resource.
      *
      * @var StaticResourceHandler\MiddlewareInterface[]
      */
-    private $middleware;
+    private array $middleware;
 
     /**
      * @throws Exception\InvalidStaticResourceMiddlewareException For any

--- a/src/StaticResourceHandler/CacheControlMiddleware.php
+++ b/src/StaticResourceHandler/CacheControlMiddleware.php
@@ -37,14 +37,13 @@ class CacheControlMiddleware implements MiddlewareInterface
         'private',
     ];
 
-    // phpcs:disable WebimpressCodingStandard.Commenting.TagWithType.InvalidTypeFormat
     /**
-     * @var array<string, list<string>> Key is a regexp; if a static resource path
-     *     matches the regexp, the array of values provided will be used as
-     *     the Cache-Control header value.
+     * Key is a regexp; if a static resource path matches the regexp, the array
+     * of values provided will be used as the Cache-Control header value.
+     *
+     * @psalm-var array<string, list<string>>
      */
-    private $cacheControlDirectives;
-    // phpcs:enable
+    private array $cacheControlDirectives;
 
     public function __construct(array $cacheControlDirectives = [])
     {

--- a/src/StaticResourceHandler/ClearStatCacheMiddleware.php
+++ b/src/StaticResourceHandler/ClearStatCacheMiddleware.php
@@ -21,17 +21,13 @@ class ClearStatCacheMiddleware implements MiddlewareInterface
      * Interval at which to clear fileystem stat cache. Values below 1 indicate
      * the stat cache should ALWAYS be cleared. Otherwise, the value is the number
      * of seconds between clear operations.
-     *
-     * @var int
      */
-    private $interval;
+    private int $interval;
 
     /**
      * When the filesystem stat cache was last cleared.
-     *
-     * @var int
      */
-    private $lastCleared;
+    private int $lastCleared = 0;
 
     public function __construct(int $interval)
     {

--- a/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
+++ b/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
@@ -100,28 +100,26 @@ class ContentTypeFilterMiddleware implements MiddlewareInterface
 
     /**
      * Cache the file extensions (type) for valid static file
-     *
-     * @var array
      */
-    private $cacheTypeFile = [];
+    private array $cacheTypeFile = [];
 
-    // phpcs:disable WebimpressCodingStandard.Commenting.TagWithType.InvalidTypeFormat
-    /** @var array<string, string> Extension => mimetype map */
-    private $typeMap;
-    // phpcs:enable
-
-    // phpcs:disable WebimpressCodingStandard.Commenting.TagWithType.InvalidParamName
     /**
-     * @param null|array<string, string> $typeMap Map of extensions to Content-Type
-     *     values. If `null` is provided, the default list in TYPE_MAP_DEFAULT will
-     *     be used. Otherwise, the list provided is used verbatim.
+     * Extension => mimetype map
+     *
+     * @psalm-var array<string, string>
+     */
+    private array $typeMap;
+
+    /**
+     * @param null|array $typeMap Map of extensions to Content-Type values. If
+     *     `null` is provided, the default list in TYPE_MAP_DEFAULT will be
+     *     used. Otherwise, the list provided is used verbatim.
+     * @psalm-param null|array<string, string> $typeMap
      */
     public function __construct(?array $typeMap = null)
     {
         $this->typeMap = $typeMap ?? self::TYPE_MAP_DEFAULT;
     }
-
-    // phpcs:enable
 
     /**
      * {@inheritDoc}

--- a/src/StaticResourceHandler/ETagMiddleware.php
+++ b/src/StaticResourceHandler/ETagMiddleware.php
@@ -34,7 +34,7 @@ class ETagMiddleware implements MiddlewareInterface
     public const ETAG_VALIDATION_WEAK   = 'weak';
 
     /** @var string[] */
-    private $allowedETagValidationTypes = [
+    private array $allowedETagValidationTypes = [
         self::ETAG_VALIDATION_STRONG,
         self::ETAG_VALIDATION_WEAK,
     ];
@@ -43,15 +43,13 @@ class ETagMiddleware implements MiddlewareInterface
      * @var string[] Array of regexp; if a path matches a regexp, an ETag will
      *     be emitted for the static file resource.
      */
-    private $etagDirectives;
+    private array $etagDirectives;
 
     /**
      * ETag validation type, 'weak' means Weak Validation, 'strong' means Strong Validation,
      * other value will not response ETag header.
-     *
-     * @var string
      */
-    private $etagValidationType;
+    private string $etagValidationType;
 
     public function __construct(array $etagDirectives = [], string $etagValidationType = self::ETAG_VALIDATION_WEAK)
     {

--- a/src/StaticResourceHandler/FileLocationRepository.php
+++ b/src/StaticResourceHandler/FileLocationRepository.php
@@ -27,10 +27,9 @@ use function trim;
 class FileLocationRepository implements FileLocationRepositoryInterface
 {
     /**
-     * @var array
      * Associative array of URI prefixes and directories
      */
-    private $mappedDocRoots = [];
+    private array $mappedDocRoots = [];
 
     /**
      * Initialize repository with default mapped document roots

--- a/src/StaticResourceHandler/GzipMiddleware.php
+++ b/src/StaticResourceHandler/GzipMiddleware.php
@@ -30,18 +30,15 @@ use const ZLIB_ENCODING_GZIP;
 
 class GzipMiddleware implements MiddlewareInterface
 {
-    // phpcs:disable WebimpressCodingStandard.Commenting.TagWithType.InvalidTypeFormat
     /**
-     * @var array<int, string>
+     * @psalm-var array<int, string>
      */
     public const COMPRESSION_CONTENT_ENCODING_MAP = [
         ZLIB_ENCODING_DEFLATE => 'deflate',
         ZLIB_ENCODING_GZIP    => 'gzip',
     ];
-    // phpcs:enable
 
-    /** @var int */
-    private $compressionLevel;
+    private int $compressionLevel;
 
     /**
      * @param int $compressionLevel Compression level to use. Values less than

--- a/src/StaticResourceHandler/LastModifiedMiddleware.php
+++ b/src/StaticResourceHandler/LastModifiedMiddleware.php
@@ -23,7 +23,7 @@ class LastModifiedMiddleware implements MiddlewareInterface
     use ValidateRegexTrait;
 
     /** @var string[] */
-    private $lastModifiedDirectives = [];
+    private array $lastModifiedDirectives = [];
 
     /**
      * @var string[] Array of regexex indicating paths/file types that should

--- a/src/StaticResourceHandler/MiddlewareQueue.php
+++ b/src/StaticResourceHandler/MiddlewareQueue.php
@@ -20,7 +20,7 @@ use function array_shift;
 class MiddlewareQueue
 {
     /** @var MiddlewareInterface[] */
-    private $middleware;
+    private array $middleware;
 
     public function __construct(array $middleware)
     {

--- a/src/StaticResourceHandler/StaticResourceResponse.php
+++ b/src/StaticResourceHandler/StaticResourceResponse.php
@@ -22,25 +22,21 @@ class StaticResourceResponse
     /** @var int */
     private $contentLength = 0;
 
-    // phpcs:disable WebimpressCodingStandard.Commenting.TagWithType.InvalidTypeFormat
-    /** @var array<string, string> */
-    private $headers = [];
-    // phpcs:enable
+    /** @psalm-var array<string, string> */
+    private array $headers = [];
 
     /**
-     * @var bool Does this response represent a failure to locate the requested
-     *     resource and/or that it cannot be requested?
+     * Does this response represent a failure to locate the requested resource
+     * and/or that it cannot be requested?
      */
-    private $isFailure = false;
+    private bool $isFailure = false;
 
     /** @var callable */
     private $responseContentCallback;
 
-    /** @var bool */
-    private $sendContent = true;
+    private bool $sendContent = true;
 
-    /** @var int */
-    private $status;
+    private int $status;
 
     /**
      * @param null|callable $responseContentCallback Callback to use when emitting

--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -31,8 +31,7 @@ class SwooleEmitter implements EmitterInterface
      */
     public const CHUNK_SIZE = 2097152; // 2 MB
 
-    /** @var SwooleHttpResponse */
-    private $swooleResponse;
+    private SwooleHttpResponse $swooleResponse;
 
     public function __construct(SwooleHttpResponse $response)
     {

--- a/src/SwooleStream.php
+++ b/src/SwooleStream.php
@@ -26,24 +26,18 @@ final class SwooleStream implements StreamInterface
 {
     /**
      * Memoized body content, as pulled via SwooleHttpRequest::rawContent().
-     *
-     * @var string
      */
-    private $body;
+    private ?string $body = null;
 
     /**
      * Length of the request body content.
-     *
-     * @var int
      */
-    private $bodySize;
+    private ?int $bodySize = null;
 
     /**
      * Index to which we have seek'd or read within the request body.
-     *
-     * @var int
      */
-    private $index = 0;
+    private int $index = 0;
 
     /**
      * Swoole request containing the body contents.
@@ -78,15 +72,17 @@ final class SwooleStream implements StreamInterface
         // Set the internal index to the end of the string
         $this->index = $size;
 
-        if ($index) {
+        if ($index && null !== $this->body) {
             // Per PSR-7 spec, if we have seeked or read to a given position in
             // the string, we should only return the contents from that position
             // forward.
-            return substr($this->body, $index);
+            $remaining = substr($this->body, $index);
+
+            return $remaining ?: '';
         }
 
         // If we're at the start of the content, return all of it.
-        return $this->body;
+        return (string) $this->body;
     }
 
     /**


### PR DESCRIPTION
This patch adds property typehints wherever they can be added safely (examples where they cannot are resources and callbacks), and removes docblock annotations where they were redundant.

Fixes #38
