### PR TITLE
Ensure AccessLogDataMap does not throw fatal error due to uninitialized typed properties

### DIFF
--- a/test/Log/AccessLogDataMapTest.php
+++ b/test/Log/AccessLogDataMapTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace MezzioTest\Swoole\Log;
 
 use Mezzio\Swoole\Log\AccessLogDataMap;
+use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -83,5 +84,15 @@ class AccessLogDataMapTest extends TestCase
         $map                   = AccessLogDataMap::createWithPsrResponse($this->request, $this->response, false);
 
         $this->assertEquals($expectedIp, $map->getClientIp());
+    }
+
+    public function testDoesNotRaiseErrorWhenAccessingStatusViaStaticResource(): void
+    {
+        $staticResource = $this->createMock(StaticResourceResponse::class);
+        $staticResource->expects($this->once())->method('getStatus')->willReturn(200);
+
+        $map = AccessLogDataMap::createWithStaticResource($this->request, $staticResource);
+
+        $this->assertSame('200', $map->getStatus());
     }
 }


### PR DESCRIPTION
The `AccessLogDataMap` has named constructors that ensure either the `$psrResponse` or `$staticResource` properties are initialized.  However, internally, it also checks to see if one or the other is _set_ in order to determine which actions to take and/or values to return.  When uninitialized, these can lead to fatal errors.

However, when `null`, we get `PossiblyNullReference` notices from Psalm.  To fix these, we need to do proper conditionals instead of ternary statements, and raise exceptions when neither are present.
