### PR TITLE
Allow access to dispatcher and Swoole HTTP Server instances in extending classes

### DIFF
--- a/src/SwooleRequestHandlerRunner.php
+++ b/src/SwooleRequestHandlerRunner.php
@@ -42,9 +42,9 @@ class SwooleRequestHandlerRunner extends RequestHandlerRunner
      */
     public const DEFAULT_PROCESS_NAME = 'mezzio';
 
-    private EventDispatcherInterface $dispatcher;
+    protected EventDispatcherInterface $dispatcher;
 
-    private SwooleHttpServer $httpServer;
+    protected SwooleHttpServer $httpServer;
 
     public function __construct(
         SwooleHttpServer $httpServer,


### PR DESCRIPTION
To allow changing how events are attached, particularly when using third-party extensions that need to attach directly to the server and decorate the main functionality (e.g., timers), the swoole instance should be exposed.  Exposing the dispatcher also allows extending the various internal methods in a way that allows their individual logic to be wrapped.

Fixes #44
