### PR TITLE
Ensured unpacked array has at least 2 elements to avoid undefined index warning

### DIFF
--- a/src/Command/IsRunningTrait.php
+++ b/src/Command/IsRunningTrait.php
@@ -21,6 +21,7 @@ trait IsRunningTrait
      */
     public function isRunning(): bool
     {
+        /** @psalm-var list<string> */
         $pids = $this->pidManager->read();
 
         if ([] === $pids) {

--- a/src/Command/IsRunningTrait.php
+++ b/src/Command/IsRunningTrait.php
@@ -12,6 +12,8 @@ namespace Mezzio\Swoole\Command;
 
 use Swoole\Process as SwooleProcess;
 
+use function array_pad;
+
 trait IsRunningTrait
 {
     /**
@@ -25,7 +27,7 @@ trait IsRunningTrait
             return false;
         }
 
-        [$masterPid, $managerPid] = $pids;
+        [$masterPid, $managerPid] = array_pad($pids, 2, null);
 
         if ($managerPid) {
             // Swoole process mode


### PR DESCRIPTION
This is a small fix for a warning I have noticed when running the `mezzio:swoole:stop` command:

`Warning: Undefined array key 1 in /home/shlink/vendor/mezzio/mezzio-swoole/src/Command/IsRunningTrait.php on line 28`

It's caused when the `$pids` array only has one element. Using `array_pad` we ensure the array is filled with nulls up to 2 positions, which keeps the same behavior but prevents the warning.
