### PR TITLE
Add typed `pidManager` property to `IsRunningTrait`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -28,12 +28,6 @@
       <code>0</code>
       <code>0</code>
     </InvalidArgument>
-    <MixedMethodCall occurrences="1">
-      <code>read</code>
-    </MixedMethodCall>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;pidManager</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Command/ReloadCommand.php">
     <PossiblyNullArgument occurrences="2">
@@ -63,9 +57,6 @@
     <MixedMethodCall occurrences="1">
       <code>set</code>
     </MixedMethodCall>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;pidManager</code>
-    </UndefinedThisPropertyAssignment>
   </file>
   <file src="src/Command/StatusCommandFactory.php">
     <MixedArgument occurrences="1">

--- a/src/Command/IsRunningTrait.php
+++ b/src/Command/IsRunningTrait.php
@@ -8,18 +8,20 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole\Command;
 
+use Mezzio\Swoole\PidManager;
 use Swoole\Process as SwooleProcess;
 
 use function array_pad;
 
 trait IsRunningTrait
 {
+    private PidManager $pidManager;
+
     /**
      * Is the swoole HTTP server running?
      */
     public function isRunning(): bool
     {
-        /** @psalm-var list<string> */
         $pids = $this->pidManager->read();
 
         if ([] === $pids) {

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Webmozart\Assert\Assert;
 
 use function file_exists;
 
@@ -48,6 +49,9 @@ EOH;
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
+        $pidManager      = $container->get(PidManager::class);
+        Assert::isInstanceOf($pidManager, PidManager::class);
+        $this->pidManager = $pidManager;
         parent::__construct();
     }
 
@@ -77,7 +81,6 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->pidManager = $this->container->get(PidManager::class);
         if ($this->isRunning()) {
             $output->writeln('<error>Server is already running!</error>');
             return 1;

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -27,8 +27,6 @@ EOH;
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:swoole:status';
 
-    private PidManager $pidManager;
-
     public function __construct(PidManager $pidManager)
     {
         $this->pidManager = $pidManager;

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -48,8 +48,6 @@ EOH;
      */
     public int $waitThreshold = 60;
 
-    private PidManager $pidManager;
-
     public function __construct(PidManager $pidManager)
     {
         $this->killProcess = Closure::fromCallable([SwooleProcess::class, 'kill']);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | yes/no
| BC Break      | yes/no
| New Feature   | yes/no
| RFC           | yes/no
| QA            | yes/no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

In the `StartCommand` implementation, the `pidManager` property was dynamically assigned.
Although, it was not set via `__construct`.

Since the `IsRunningTrait` depends on the PidManager, moving that property to the trait seems to be the proper option.
