### PR TITLE
Fixes issue 68 - stream content if size is unknown

### DIFF
--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -86,7 +86,7 @@ class SwooleEmitter implements EmitterInterface
             return;
         }
 
-        if ($body->getSize() <= static::CHUNK_SIZE) {
+        if ($body->getSize() !== null && $body->getSize() <= static::CHUNK_SIZE) {
             $this->swooleResponse->end($body->getContents());
             return;
         }

--- a/test/SwooleEmitterTest.php
+++ b/test/SwooleEmitterTest.php
@@ -160,19 +160,15 @@ class SwooleEmitterTest extends TestCase
 
     public function testEmitWithUnknownSizeContentBody(): void
     {
-        $content  = 'unknown length';
+        $content = 'unknown length';
 
-        $stream = fopen('php://memory','r+');
-        fwrite($stream, $content);
-        rewind($stream);
-
-        $streamWithSimulatedUnknownSize = new class($stream) extends Stream
+        /** @psalm-suppress PropertyNotSetInConstructor */
+        $streamWithSimulatedUnknownSize = new class ($content) extends Stream
         {
             public function getSize(): ?int
             {
                 return null;
             }
-
         };
 
         $response = (new Response($streamWithSimulatedUnknownSize))


### PR DESCRIPTION
Signed-off-by: Marcus Grymmare <marcus.grymmare@binosight.com>




|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR fixes issue #68, which sends the entire stream content at once when the size is unknown. 


