### PR TITLE
Fix deprecation in request time formatting for access logs

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -15,7 +15,17 @@
     </projectFiles>
 
     <issueHandlers>
+        <InternalClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Mezzio\Swoole\Log\StrftimeToICUFormatMap"/>
+            </errorLevel>
+        </InternalClass>
+
         <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="Mezzio\Swoole\Log\StrftimeToICUFormatMap::mapStrftimeToICU"/>
+            </errorLevel>
+
             <errorLevel type="suppress">
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
             </errorLevel>

--- a/src/Log/AccessLogDataMap.php
+++ b/src/Log/AccessLogDataMap.php
@@ -423,13 +423,11 @@ class AccessLogDataMap
             case 'usec':
                 return sprintf('[%s]', round($time * 1E6));
             default:
+                // Cast to int first, as it may be a float
                 $time = (int) $time;
-                return sprintf(
-                    '[%s]',
-                    IntlDateFormatter::formatObject(
-                        new DateTimeImmutable('@' . $time),
-                        StrftimeToICUFormatMap::mapStrftimeToICU($format)
-                    )
+                return IntlDateFormatter::formatObject(
+                    new DateTimeImmutable('@' . $time),
+                    '[' . StrftimeToICUFormatMap::mapStrftimeToICU($format) . ']'
                 );
         }
     }

--- a/src/Log/AccessLogDataMap.php
+++ b/src/Log/AccessLogDataMap.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole\Log;
 
+use DateTimeImmutable;
+use IntlDateFormatter;
 use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
 use Psr\Http\Message\ResponseInterface as PsrResponse;
 use RuntimeException;
@@ -26,7 +28,6 @@ use function microtime;
 use function preg_match;
 use function round;
 use function sprintf;
-use function strftime;
 use function strpos;
 use function strtolower;
 use function substr;
@@ -422,7 +423,14 @@ class AccessLogDataMap
             case 'usec':
                 return sprintf('[%s]', round($time * 1E6));
             default:
-                return sprintf('[%s]', strftime($format, (int) $time));
+                $time = (int) $time;
+                return sprintf(
+                    '[%s]',
+                    IntlDateFormatter::formatObject(
+                        new DateTimeImmutable('@' . $time),
+                        StrftimeToICUFormatMap::mapStrftimeToICU($format)
+                    )
+                );
         }
     }
 

--- a/src/Log/AccessLogDataMap.php
+++ b/src/Log/AccessLogDataMap.php
@@ -424,10 +424,10 @@ class AccessLogDataMap
                 return sprintf('[%s]', round($time * 1E6));
             default:
                 // Cast to int first, as it may be a float
-                $time = (int) $time;
+                $requestTime = new DateTimeImmutable('@' . (int) $time);
                 return IntlDateFormatter::formatObject(
-                    new DateTimeImmutable('@' . $time),
-                    '[' . StrftimeToICUFormatMap::mapStrftimeToICU($format) . ']'
+                    $requestTime,
+                    '[' . StrftimeToICUFormatMap::mapStrftimeToICU($format, $requestTime) . ']'
                 );
         }
     }

--- a/src/Log/StrftimeToICUFormatMap.php
+++ b/src/Log/StrftimeToICUFormatMap.php
@@ -17,6 +17,8 @@ use function time;
  * This will translate all but %X, %x, and %c, for which there are no ICU
  * equivalents.
  *
+ * @internal
+ *
  * @see https://www.php.net/strftime for PHP strftime format strings
  * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/ for ICU Date/Time format strings
  */

--- a/src/Log/StrftimeToICUFormatMap.php
+++ b/src/Log/StrftimeToICUFormatMap.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole\Log;
 
+use DateTimeInterface;
 use RuntimeException;
 use Webmozart\Assert\Assert;
 
 use function preg_replace_callback;
 use function sprintf;
-use function time;
 
 /**
  * Translate a strftime format to an ICU date/time format.
@@ -24,92 +24,100 @@ use function time;
  */
 final class StrftimeToICUFormatMap
 {
-    public static function mapStrftimeToICU(string $format): string
+    public static function mapStrftimeToICU(string $format, DateTimeInterface $requestTime): string
     {
         return preg_replace_callback(
             '/(?P<token>%[aAbBcCdDeFgGhHIjklmMpPrRsSTuUVwWxXyYzZ])/',
-            function (array $matches) {
-                Assert::keyExists($matches, 'token');
-                Assert::string($matches['token']);
-                switch (true) {
-                    case $matches['token'] === '%a':
-                        return 'eee';
-                    case $matches['token'] === '%A':
-                        return 'eeee';
-                    case $matches['token'] === '%b':
-                        return 'MMM';
-                    case $matches['token'] === '%B':
-                        return 'MMMM';
-                    case $matches['token'] === '%C':
-                        return 'yy';
-                    case $matches['token'] === '%d':
-                        return 'dd';
-                    case $matches['token'] === '%D':
-                        return 'MM/dd/yy';
-                    case $matches['token'] === '%e':
-                        return ' d';
-                    case $matches['token'] === '%F':
-                        return 'y-MM-dd';
-                    case $matches['token'] === '%g':
-                        return 'yy';
-                    case $matches['token'] === '%G':
-                        return 'y';
-                    case $matches['token'] === '%h':
-                        return 'MMM';
-                    case $matches['token'] === '%H':
-                        return 'HH';
-                    case $matches['token'] === '%I':
-                        return 'KK';
-                    case $matches['token'] === '%j':
-                        return 'D';
-                    case $matches['token'] === '%k':
-                        return ' H';
-                    case $matches['token'] === '%l':
-                        return ' h';
-                    case $matches['token'] === '%m':
-                        return 'MM';
-                    case $matches['token'] === '%M':
-                        return 'mm';
-                    case $matches['token'] === '%p':
-                        return 'a';
-                    case $matches['token'] === '%P':
-                        return 'a';
-                    case $matches['token'] === '%r':
-                        return ' h:mm:ss a';
-                    case $matches['token'] === '%R':
-                        return 'HH:mm';
-                    case $matches['token'] === '%S':
-                        return 'ss';
-                    case $matches['token'] === '%s':
-                        return (string) time();
-                    case $matches['token'] === '%T':
-                        return 'HH:mm:ss';
-                    case $matches['token'] === '%u':
-                        return 'e';
-                    case $matches['token'] === '%U':
-                        return 'ww';
-                    case $matches['token'] === '%w':
-                        return 'c';
-                    case $matches['token'] === '%W':
-                        return 'ww';
-                    case $matches['token'] === '%V':
-                        return 'ww';
-                    case $matches['token'] === '%y':
-                        return 'yy';
-                    case $matches['token'] === '%Y':
-                        return 'y';
-                    case $matches['token'] === '%z':
-                        return 'xx';
-                    case $matches['token'] === '%Z':
-                        return 'z';
-                    default:
-                        throw new RuntimeException(sprintf(
-                            'The request time format token "%s" is unsupported; please use ICU Date/Time format codes',
-                            $matches['token']
-                        ));
-                }
-            },
+            self::generateMapCallback($requestTime),
             $format
         );
+    }
+
+    /**
+     * @psalm-return callable(array<array-key, string>):string
+     */
+    private static function generateMapCallback(DateTimeInterface $requestTime): callable
+    {
+        /** @psalm-param array<array-key, string> */
+        return function (array $matches) use ($requestTime): string {
+            Assert::keyExists($matches, 'token');
+            switch (true) {
+                case $matches['token'] === '%a':
+                    return 'eee';
+                case $matches['token'] === '%A':
+                    return 'eeee';
+                case $matches['token'] === '%b':
+                    return 'MMM';
+                case $matches['token'] === '%B':
+                    return 'MMMM';
+                case $matches['token'] === '%C':
+                    return 'yy';
+                case $matches['token'] === '%d':
+                    return 'dd';
+                case $matches['token'] === '%D':
+                    return 'MM/dd/yy';
+                case $matches['token'] === '%e':
+                    return ' d';
+                case $matches['token'] === '%F':
+                    return 'y-MM-dd';
+                case $matches['token'] === '%g':
+                    return 'yy';
+                case $matches['token'] === '%G':
+                    return 'y';
+                case $matches['token'] === '%h':
+                    return 'MMM';
+                case $matches['token'] === '%H':
+                    return 'HH';
+                case $matches['token'] === '%I':
+                    return 'KK';
+                case $matches['token'] === '%j':
+                    return 'D';
+                case $matches['token'] === '%k':
+                    return ' H';
+                case $matches['token'] === '%l':
+                    return ' h';
+                case $matches['token'] === '%m':
+                    return 'MM';
+                case $matches['token'] === '%M':
+                    return 'mm';
+                case $matches['token'] === '%p':
+                    return 'a';
+                case $matches['token'] === '%P':
+                    return 'a';
+                case $matches['token'] === '%r':
+                    return ' h:mm:ss a';
+                case $matches['token'] === '%R':
+                    return 'HH:mm';
+                case $matches['token'] === '%S':
+                    return 'ss';
+                case $matches['token'] === '%s':
+                    return (string) $requestTime->getTimestamp();
+                case $matches['token'] === '%T':
+                    return 'HH:mm:ss';
+                case $matches['token'] === '%u':
+                    return 'e';
+                case $matches['token'] === '%U':
+                    return 'ww';
+                case $matches['token'] === '%w':
+                    return 'c';
+                case $matches['token'] === '%W':
+                    return 'ww';
+                case $matches['token'] === '%V':
+                    return 'ww';
+                case $matches['token'] === '%y':
+                    return 'yy';
+                case $matches['token'] === '%Y':
+                    return 'y';
+                case $matches['token'] === '%z':
+                    return 'xx';
+                case $matches['token'] === '%Z':
+                    return 'z';
+                default:
+                    throw new RuntimeException(sprintf(
+                        'The request time format token "%s" is unsupported; please use ICU Date/Time format codes',
+                        $matches['token']
+                    ));
+            }
+        };
     }
 }

--- a/src/Log/StrftimeToICUFormatMap.php
+++ b/src/Log/StrftimeToICUFormatMap.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Swoole\Log;
+
+use RuntimeException;
+use Webmozart\Assert\Assert;
+
+use function preg_replace_callback;
+use function sprintf;
+use function time;
+
+/**
+ * Translate a strftime format to an ICU date/time format.
+ *
+ * This will translate all but %X, %x, and %c, for which there are no ICU
+ * equivalents.
+ *
+ * @see https://www.php.net/strftime for PHP strftime format strings
+ * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/ for ICU Date/Time format strings
+ */
+final class StrftimeToICUFormatMap
+{
+    public static function mapStrftimeToICU(string $format): string
+    {
+        return preg_replace_callback(
+            '/(?P<token>%[aAbBcCdDeFgGhHIjklmMpPrRsSTuUVwWxXyYzZ])/',
+            function (array $matches) {
+                Assert::keyExists($matches, 'token');
+                Assert::string($matches['token']);
+                switch (true) {
+                    case $matches['token'] === '%a':
+                        return 'eee';
+                    case $matches['token'] === '%A':
+                        return 'eeee';
+                    case $matches['token'] === '%b':
+                        return 'MMM';
+                    case $matches['token'] === '%B':
+                        return 'MMMM';
+                    case $matches['token'] === '%C':
+                        return 'yy';
+                    case $matches['token'] === '%d':
+                        return 'dd';
+                    case $matches['token'] === '%D':
+                        return 'MM/dd/yy';
+                    case $matches['token'] === '%e':
+                        return ' d';
+                    case $matches['token'] === '%F':
+                        return 'y-MM-dd';
+                    case $matches['token'] === '%g':
+                        return 'yy';
+                    case $matches['token'] === '%G':
+                        return 'y';
+                    case $matches['token'] === '%h':
+                        return 'MMM';
+                    case $matches['token'] === '%H':
+                        return 'HH';
+                    case $matches['token'] === '%I':
+                        return 'KK';
+                    case $matches['token'] === '%j':
+                        return 'D';
+                    case $matches['token'] === '%k':
+                        return ' H';
+                    case $matches['token'] === '%l':
+                        return ' h';
+                    case $matches['token'] === '%m':
+                        return 'MM';
+                    case $matches['token'] === '%M':
+                        return 'mm';
+                    case $matches['token'] === '%p':
+                        return 'a';
+                    case $matches['token'] === '%P':
+                        return 'a';
+                    case $matches['token'] === '%r':
+                        return ' h:mm:ss a';
+                    case $matches['token'] === '%R':
+                        return 'HH:mm';
+                    case $matches['token'] === '%S':
+                        return 'ss';
+                    case $matches['token'] === '%s':
+                        return (string) time();
+                    case $matches['token'] === '%T':
+                        return 'HH:mm:ss';
+                    case $matches['token'] === '%u':
+                        return 'e';
+                    case $matches['token'] === '%U':
+                        return 'ww';
+                    case $matches['token'] === '%w':
+                        return 'c';
+                    case $matches['token'] === '%W':
+                        return 'ww';
+                    case $matches['token'] === '%V':
+                        return 'ww';
+                    case $matches['token'] === '%y':
+                        return 'yy';
+                    case $matches['token'] === '%Y':
+                        return 'y';
+                    case $matches['token'] === '%z':
+                        return 'xx';
+                    case $matches['token'] === '%Z':
+                        return 'z';
+                    default:
+                        throw new RuntimeException(sprintf(
+                            'The request time format token "%s" is unsupported; please use ICU Date/Time format codes',
+                            $matches['token']
+                        ));
+                }
+            },
+            $format
+        );
+    }
+}

--- a/test/Log/StrftimeToICUFormatMapTest.php
+++ b/test/Log/StrftimeToICUFormatMapTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole\Log;
+
+use Mezzio\Swoole\Log\StrftimeToICUFormatMap;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class StrftimeToICUFormatMapTest extends TestCase
+{
+    public function testPatternsUsedInAccessLogFormatter(): void
+    {
+        $this->assertSame('dd/MMM/y:HH:mm:ss xx', StrftimeToICUFormatMap::mapStrftimeToICU('%d/%b/%Y:%H:%M:%S %z'));
+    }
+
+    public function testDoesNotReplaceICUFormats(): void
+    {
+        $this->assertSame('dd/MMM/y:HH:mm:ss xx', StrftimeToICUFormatMap::mapStrftimeToICU('dd/MMM/y:HH:mm:ss xx'));
+    }
+
+    /** @psalm-return array<string, array{0: non-empty-string}> */
+    public function unsupportedFormats(): array
+    {
+        return [
+            '%c' => ['%c'],
+            '%x' => ['%x'],
+            '%X' => ['%X'],
+        ];
+    }
+
+    /**
+     * @dataProvider unsupportedFormats
+     * @psalm-param non-empty-string $format
+     */
+    public function testRaisesExceptionForUnsupportedFormats(string $format): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('unsupported');
+        StrftimeToICUFormatMap::mapStrftimeToICU($format);
+    }
+}

--- a/test/Log/StrftimeToICUFormatMapTest.php
+++ b/test/Log/StrftimeToICUFormatMapTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MezzioTest\Swoole\Log;
 
+use DateTimeImmutable;
 use Mezzio\Swoole\Log\StrftimeToICUFormatMap;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -12,12 +13,18 @@ class StrftimeToICUFormatMapTest extends TestCase
 {
     public function testPatternsUsedInAccessLogFormatter(): void
     {
-        $this->assertSame('dd/MMM/y:HH:mm:ss xx', StrftimeToICUFormatMap::mapStrftimeToICU('%d/%b/%Y:%H:%M:%S %z'));
+        $this->assertSame(
+            'dd/MMM/y:HH:mm:ss xx',
+            StrftimeToICUFormatMap::mapStrftimeToICU('%d/%b/%Y:%H:%M:%S %z', new DateTimeImmutable('now'))
+        );
     }
 
     public function testDoesNotReplaceICUFormats(): void
     {
-        $this->assertSame('dd/MMM/y:HH:mm:ss xx', StrftimeToICUFormatMap::mapStrftimeToICU('dd/MMM/y:HH:mm:ss xx'));
+        $this->assertSame(
+            'dd/MMM/y:HH:mm:ss xx',
+            StrftimeToICUFormatMap::mapStrftimeToICU('dd/MMM/y:HH:mm:ss xx', new DateTimeImmutable('now'))
+        );
     }
 
     /** @psalm-return array<string, array{0: non-empty-string}> */
@@ -38,6 +45,6 @@ class StrftimeToICUFormatMapTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('unsupported');
-        StrftimeToICUFormatMap::mapStrftimeToICU($format);
+        StrftimeToICUFormatMap::mapStrftimeToICU($format, new DateTimeImmutable('now'));
     }
 }


### PR DESCRIPTION
AccessLogFormatter calls on AccesLogDataMap to format a number of strings, including request times; these are generally used in cookies and/or header values.  Previously, we used `strftime()` to format date/time values.  However, this is deprecated starting in PHP 8.1, with the recommendation of using `IntlDateFormatter` for purposes of formatting date/time strings in a locale-specific way.  Because I'm unclear on whether the formats will always come from internal classes, or if they might come from external sources (e.g., cookie values), I've created a new final class, `Mezzio\Swoole\StrftimeToICUFormatMap` for mapping strftime formats to the ICU equivalents.  I've added some basic tests for the class, which include demonstrating that the formats we use internally all get translated correctly.  I've also added a test case for `AccessLogDataMap::getRequestTime()` to demonstrate that it generates the same values.

Targeting the 3.5 series, as this is technically a bug in our PHP 8.1 support.
