### PR TITLE
Fix error flagged by Psalm

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.13.1@5cf660f63b548ccd4a56f62d916ee4d6028e01a3">
+<files psalm-version="v4.15.0@a1b5e489e6fcebe40cb804793d964e99fc347820">
   <file src="src/AbstractStaticResourceHandlerFactory.php">
     <MixedArgument occurrences="3">
       <code>$compressionLevel</code>

--- a/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
+++ b/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
@@ -115,7 +115,6 @@ class InotifyFileWatcher implements FileWatcherInterface
             $paths = array_merge($paths, $this->listSubdirectoriesRecursively($filename));
         }
 
-        $paths = array_values($paths);
         Assert::allStringNotEmpty($paths);
 
         return $paths;


### PR DESCRIPTION
After merging #77, GHA [noted a failure](https://github.com/mezzio/mezzio-swoole/runs/4512183399?check_suite_focus=true).  This patch removes a redundant cast operation, and updates the Psalm baseline to note fixes.
