### PR TITLE
Document proper aggregation of Swoole ConfigProvider

### DIFF
--- a/docs/book/v3/cookbook/swoole-not-starting.md
+++ b/docs/book/v3/cookbook/swoole-not-starting.md
@@ -1,0 +1,73 @@
+# Swoole-based server always returns home page
+
+## The problem
+
+You have started your Swoole-based web-server using `./vendor/bin/laminas mezzio:swoole:start`, but every request is returned with a status 200 response and the contents of the home page.
+
+## The solution
+
+This is generally caused by having the mezzio-swoole configuration provider too early in your application configuration, which then causes the default Mezzio configuration to overwrite the mezzio-swoole application runner.
+
+As an example, if the definition of the `ConfigAggregator` in your `config/config.php` file  looks something like this:
+
+```php
+$aggregator = new ConfigAggregator([
+    \Mezzio\Swoole\ConfigProvider::class,
+    \Mezzio\Plates\ConfigProvider::class,
+    \Mezzio\Helper\ConfigProvider::class,
+    \Mezzio\Router\FastRouteRouter\ConfigProvider::class,
+    \Laminas\HttpHandlerRunner\ConfigProvider::class,
+    // Include cache configuration
+    new \Laminas\ConfigAggregator\ArrayProvider($cacheConfig),
+    \Mezzio\Helper\ConfigProvider::class,
+    \Mezzio\ConfigProvider::class,
+    \Mezzio\Router\ConfigProvider::class,
+    \Laminas\Diactoros\ConfigProvider::class,
+    // Default App module config
+    \App\ConfigProvider::class,
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new \Laminas\ConfigAggregator\PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+    // Load development config if it exists
+    new \Laminas\ConfigAggregator\PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+```
+
+Note the position of the `Mezzio\Swoole\ConfigProvider::class` entry at the top.
+This can happen if you have previously removed the original entry from the `config/config.php` as provided by the skeleton project, or if you hand-crafted your `config/config.php` file`, and then later used `composer require mezzio/mezzio-swoole`, as the [component installer](https://docs.laminas.dev/laminas-component-installer/) injects at the start of the aggregator definition.
+
+The mezzio-swoole package provides a custom implementation of an [HTTP Handler Runner](https://docs.laminas.dev/laminas-httphandlerrunner/).
+Because it defines the _same service name_ as the one provided by laminas/laminas-httphandlerrunner, the mezzio-swoole `ConfigProvider` must appear _later_ during aggregation to ensure it takes precedence:
+
+```php
+$aggregator = new ConfigAggregator([
+    \Mezzio\Plates\ConfigProvider::class,
+    \Mezzio\Helper\ConfigProvider::class,
+    \Mezzio\Router\FastRouteRouter\ConfigProvider::class,
+    \Laminas\HttpHandlerRunner\ConfigProvider::class,
+    \Mezzio\Swoole\ConfigProvider::class, // <-- Here or later!
+    // Include cache configuration
+    new \Laminas\ConfigAggregator\ArrayProvider($cacheConfig),
+    \Mezzio\Helper\ConfigProvider::class,
+    \Mezzio\ConfigProvider::class,
+    \Mezzio\Router\ConfigProvider::class,
+    \Laminas\Diactoros\ConfigProvider::class,
+    // Default App module config
+    \App\ConfigProvider::class,
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new \Laminas\ConfigAggregator\PhpFileProvider(realpath(__DIR__) . '/autoload/{{,*.}global,{,*.}local}.php'),
+    // Load development config if it exists
+    new \Laminas\ConfigAggregator\PhpFileProvider(realpath(__DIR__) . '/development.config.php'),
+], $cacheConfig['config_cache_path']);
+```
+
+Note the change in position for the `Mezzio\Swoole\ConfigProvider:class` entry in the above example.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
         - "Considerations when using Swoole": v3/considerations.md
       - Cookbook:
           - "Removing the StaticResourceRequestListener": v3/cookbook/static-resource-listener-removal.md
+          - "Swoole-based server always returns home page": v3/cookbook/swoole-not-starting.md
       - Migration: v3/migration.md
     - v2:
       - Introduction: v2/intro.md

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -23,13 +23,20 @@ use function getcwd;
 
 use const PHP_SAPI;
 
+/**
+ * Provide component configuration to the application.
+ *
+ * NOTE: this provider should be aggregated AFTER the laminas/laminas-httphandlerrunner
+ * config provider (class Laminas\HttpHandlerRunner\ConfigProvider) to ensure
+ * that its SwooleRequestHandlerRunner is used as the application request handler runner.
+ */
 class ConfigProvider
 {
     public function __invoke(): array
     {
         if (! extension_loaded('swoole') && ! extension_loaded('openswoole')) {
             throw new ExtensionNotLoadedException(
-                'One of either the Swoole (https://github.com/swoole/swoole-srce) or'
+                'One of either the Swoole (https://github.com/swoole/swoole-src) or'
                 . ' Open Swoole (https://www.swoole.co.uk) extensions must be loaded'
                 . ' to use mezzio/mezzio-swoole'
             );


### PR DESCRIPTION
- Adds a class docblock to the `Mezzio\Swoole\ConfigProvider` class noting that it should appear later than the `Laminas\HttpHandlerRunner\ConfigProvider` entry during configuration aggregation.
- Adds a recipe to the documentation detailing how to resolve issues caused by invalid configuration.

Fixes #59
