### PR TITLE
Docs: Removes extra `)` in logging

### DIFF
--- a/docs/book/v4/logging.md
+++ b/docs/book/v4/logging.md
@@ -18,7 +18,7 @@ By default, logging is performed to STDOUT, using an internal logger. However,
 you can use any [PSR-3 compliant logger](https://www.php-fig.org/psr/psr-3/) to
 log application details. We emit logs detailing server operations using the
 priority `Psr\Log\LogLevel::NOTICE` (unless detailing an error, such as
-inability to reload)), while `Psr\Log\LogLevel::INFO` and `Psr\Log\LogLevel::ERROR`
+inability to reload), while `Psr\Log\LogLevel::INFO` and `Psr\Log\LogLevel::ERROR`
 are used to log requests (errors are used for response statuses greater than or
 equal to 400).
 


### PR DESCRIPTION
Signed-off-by: Ishan Vyas <isvyas@gmail.com>