### PR TITLE
Add support for PHP 8.2, drop support for PHP 7.4

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -2,5 +2,8 @@
     "extensions": [
         "inotify",
         "swoole"
-    ]
+    ],
+    "ignore_php_platform_requirements": {
+        "8.2": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
             "composer/package-versions-deprecated": true
         },
         "platform": {
-            "php": "7.4.99"
+            "php": "8.0.99"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0",
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "dflydev/fig-cookies": "^2.0.1 || ^3.0",
         "laminas/laminas-cli": "^0.1.5 || ^1.0",
         "laminas/laminas-diactoros": "^2.11.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a56e23db225ff9bbc62514abb2eecf86",
+    "content-hash": "d466f0f36d7f5c9cd987004b81636132",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -126,21 +126,21 @@
         },
         {
             "name": "laminas/laminas-cli",
-            "version": "1.5.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cli.git",
-                "reference": "fb1076fbd0cb472fff3ebf9e08a7a9dbd70634a7"
+                "reference": "8476ca735f788cddc456ad660a29d9c8349554b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/fb1076fbd0cb472fff3ebf9e08a7a9dbd70634a7",
-                "reference": "fb1076fbd0cb472fff3ebf9e08a7a9dbd70634a7",
+                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/8476ca735f788cddc456ad660a29d9c8349554b0",
+                "reference": "8476ca735f788cddc456ad660a29d9c8349554b0",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0.0",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/console": "^5.3.7 || ^6.0",
                 "symfony/event-dispatcher": "^5.0 || ^6.0",
@@ -148,13 +148,13 @@
                 "webmozart/assert": "^1.10"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-mvc": "^3.1.1",
-                "laminas/laminas-servicemanager": "^3.15.1",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-mvc": "^3.3.5",
+                "laminas/laminas-servicemanager": "^3.19",
                 "mikey179/vfsstream": "2.0.x-dev",
-                "phpunit/phpunit": "^9.5.9",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.24.0"
+                "vimeo/psalm": "^4.29"
             },
             "bin": [
                 "bin/laminas"
@@ -190,24 +190,24 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-08-03T17:19:22+00:00"
+            "time": "2022-10-13T22:36:07+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.17.0",
+            "version": "2.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5"
+                "reference": "e5b6419fea007b8b4a71034edc8ec96c88d4c57d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5",
-                "reference": "5b32597aa46b83c8b85bb1cf9a6ed4fe7dd980c5",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/e5b6419fea007b8b4a71034edc8ec96c88d4c57d",
+                "reference": "e5b6419fea007b8b4a71034edc8ec96c88d4c57d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
@@ -226,9 +226,9 @@
                 "http-interop/http-factory-tests": "^0.9.0",
                 "laminas/laminas-coding-standard": "^2.4.0",
                 "php-http/psr7-integration-tests": "^1.1.1",
-                "phpunit/phpunit": "^9.5.23",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.24.0"
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
+                "vimeo/psalm": "^4.29.0"
             },
             "type": "library",
             "extra": {
@@ -287,7 +287,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-08-30T17:01:46+00:00"
+            "time": "2022-11-11T09:01:24+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -353,30 +353,30 @@
         },
         {
             "name": "laminas/laminas-httphandlerrunner",
-            "version": "2.2.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
-                "reference": "eb670c5c7167cd218c61a8b4f6ab9ce339200c16"
+                "reference": "d15af53895fd581b5a448a09fd9a4baebc4ae6e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/eb670c5c7167cd218c61a8b4f6ab9ce339200c16",
-                "reference": "eb670c5c7167cd218c61a8b4f6ab9ce339200c16",
+                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/d15af53895fd581b5a448a09fd9a4baebc4ae6e5",
+                "reference": "d15af53895fd581b5a448a09fd9a4baebc4ae6e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/http-message": "^1.0",
                 "psr/http-message-implementation": "^1.0",
                 "psr/http-server-handler": "^1.0"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-diactoros": "^2.13.0",
-                "phpunit/phpunit": "^9.5.21",
+                "laminas/laminas-diactoros": "^2.18",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.24.0"
+                "vimeo/psalm": "^4.28"
             },
             "type": "library",
             "extra": {
@@ -416,26 +416,26 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-09-17T16:24:51+00:00"
+            "time": "2022-10-25T13:41:39+00:00"
         },
         {
             "name": "laminas/laminas-stratigility",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stratigility.git",
-                "reference": "aa47a70ed02cff6109bf09aa7c3e85c574033d81"
+                "reference": "b847ad3a0a9f1c09de9bcc918454cc8d36efb6aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/aa47a70ed02cff6109bf09aa7c3e85c574033d81",
-                "reference": "aa47a70ed02cff6109bf09aa7c3e85c574033d81",
+                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/b847ad3a0a9f1c09de9bcc918454cc8d36efb6aa",
+                "reference": "b847ad3a0a9f1c09de9bcc918454cc8d36efb6aa",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1",
                 "laminas/laminas-escaper": "^2.10.0",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/http-message": "^1.0",
                 "psr/http-server-middleware": "^1.0"
             },
@@ -444,11 +444,11 @@
                 "zendframework/zend-stratigility": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-diactoros": "^2.13.0",
-                "phpunit/phpunit": "^9.5.21",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-diactoros": "^2.18",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.24.0"
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., laminas/laminas-diactoros"
@@ -496,20 +496,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-07-23T13:56:06+00:00"
+            "time": "2022-10-10T19:34:46+00:00"
         },
         {
             "name": "mezzio/mezzio",
-            "version": "3.11.0",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio.git",
-                "reference": "d5bf81f0caee6cf4b682a4bf1f8d693288bf217d"
+                "reference": "a9d6f7d6e45c37180059e5a4731a225ceb80cef1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/d5bf81f0caee6cf4b682a4bf1f8d693288bf217d",
-                "reference": "d5bf81f0caee6cf4b682a4bf1f8d693288bf217d",
+                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/a9d6f7d6e45c37180059e5a4731a225ceb80cef1",
+                "reference": "a9d6f7d6e45c37180059e5a4731a225ceb80cef1",
                 "shasum": ""
             },
             "require": {
@@ -518,7 +518,7 @@
                 "laminas/laminas-stratigility": "^3.5",
                 "mezzio/mezzio-router": "^3.7",
                 "mezzio/mezzio-template": "^2.2",
-                "php": "~7.4.0||~8.0.0||~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0||^2.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0.1",
@@ -535,18 +535,17 @@
                 "zendframework/zend-expressive": "*"
             },
             "require-dev": {
-                "filp/whoops": "^2.14.4",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-diactoros": "^2.11.2",
-                "laminas/laminas-servicemanager": "^3.10",
-                "malukenho/docheader": "^0.1.8",
-                "mezzio/mezzio-aurarouter": "^3.3.0",
-                "mezzio/mezzio-fastroute": "^3.3.0",
-                "mezzio/mezzio-laminasrouter": "^3.1.0",
-                "mockery/mockery": "^1.4.4",
-                "phpunit/phpunit": "^9.5.10",
-                "psalm/plugin-phpunit": "^0.13",
-                "vimeo/psalm": "^4.13.1"
+                "filp/whoops": "^2.14.5",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-diactoros": "^2.19",
+                "laminas/laminas-servicemanager": "^3.15",
+                "mezzio/mezzio-aurarouter": "^3.5",
+                "mezzio/mezzio-fastroute": "^3.7",
+                "mezzio/mezzio-laminasrouter": "^3.7",
+                "mockery/mockery": "^1.5.1",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17",
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "filp/whoops": "^2.1 to use the Whoops error handler",
@@ -605,25 +604,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-06-29T21:47:57+00:00"
+            "time": "2022-10-11T08:04:06+00:00"
         },
         {
             "name": "mezzio/mezzio-router",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-router.git",
-                "reference": "27075d3e9b407791abf7ba5e62954a59be4b18df"
+                "reference": "5b03ab8ef9ae8323a9093d5b9d79a69a3733968f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/27075d3e9b407791abf7ba5e62954a59be4b18df",
-                "reference": "27075d3e9b407791abf7ba5e62954a59be4b18df",
+                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/5b03ab8ef9ae8323a9093d5b9d79a69a3733968f",
+                "reference": "5b03ab8ef9ae8323a9093d5b9d79a69a3733968f",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0 || ^2.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0.1",
@@ -635,14 +634,12 @@
                 "zendframework/zend-expressive-router": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-diactoros": "^2.6",
-                "laminas/laminas-stratigility": "^3.4",
-                "phpspec/prophecy": "^1.9",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.11",
-                "psalm/plugin-phpunit": "^0.15.0",
-                "vimeo/psalm": "^4.17"
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-diactoros": "^2.18",
+                "laminas/laminas-stratigility": "^3.8",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",
@@ -688,33 +685,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-06T16:27:49+00:00"
+            "time": "2022-10-10T19:40:00+00:00"
         },
         {
             "name": "mezzio/mezzio-template",
-            "version": "2.5.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-template.git",
-                "reference": "55b5ab7988ff495a9cdb5cbfc3e81dfb49cd06a6"
+                "reference": "ac7c34aa8b11efdd1a039af16f00bb625eab45bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/55b5ab7988ff495a9cdb5cbfc3e81dfb49cd06a6",
-                "reference": "55b5ab7988ff495a9cdb5cbfc3e81dfb49cd06a6",
+                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/ac7c34aa8b11efdd1a039af16f00bb625eab45bd",
+                "reference": "ac7c34aa8b11efdd1a039af16f00bb625eab45bd",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-expressive-template": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.24",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.27.0"
+                "vimeo/psalm": "^4.28"
             },
             "suggest": {
                 "mezzio/mezzio-laminasviewrenderer": "^2.0 to use the laminas-view PhpRenderer template renderer",
@@ -752,7 +749,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-09-14T08:07:39+00:00"
+            "time": "2022-10-10T21:46:43+00:00"
         },
         {
             "name": "psr/container",
@@ -1081,30 +1078,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1125,52 +1122,48 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.16",
+            "version": "v6.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "8e9b9c8dfb33af6057c94e1b44846bee700dc5ef"
+                "reference": "b0b910724a0a0326b4481e4f8a30abb2dd442efb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8e9b9c8dfb33af6057c94e1b44846bee700dc5ef",
-                "reference": "8e9b9c8dfb33af6057c94e1b44846bee700dc5ef",
+                "url": "https://api.github.com/repos/symfony/console/zipball/b0b910724a0a0326b4481e4f8a30abb2dd442efb",
+                "reference": "b0b910724a0a0326b4481e4f8a30abb2dd442efb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=8.0.2",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.9",
-                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/string": "^5.1|^6.0"
+                "symfony/string": "^5.4|^6.0"
             },
             "conflict": {
-                "psr/log": ">=3",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/dotenv": "<5.1",
-                "symfony/event-dispatcher": "<4.4",
-                "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
+                "symfony/dependency-injection": "<5.4",
+                "symfony/dotenv": "<5.4",
+                "symfony/event-dispatcher": "<5.4",
+                "symfony/lock": "<5.4",
+                "symfony/process": "<5.4"
             },
             "provide": {
-                "psr/log-implementation": "1.0|2.0"
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
-                "psr/log": "^1|^2",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
-                "symfony/lock": "^4.4|^5.0|^6.0",
-                "symfony/process": "^4.4|^5.0|^6.0",
-                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/event-dispatcher": "^5.4|^6.0",
+                "symfony/lock": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -1210,7 +1203,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.16"
+                "source": "https://github.com/symfony/console/tree/v6.0.15"
             },
             "funding": [
                 {
@@ -1226,111 +1219,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T14:09:27+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-10-26T21:42:20+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.9",
+            "version": "v6.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc"
+                "reference": "5c85b58422865d42c6eb46f7693339056db098a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc",
-                "reference": "8e6ce1cc0279e3ff3c8ff0f43813bc88d21ca1bc",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5c85b58422865d42c6eb46f7693339056db098a8",
+                "reference": "5c85b58422865d42c6eb46f7693339056db098a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/event-dispatcher-contracts": "^2|^3",
-                "symfony/polyfill-php80": "^1.16"
+                "php": ">=8.0.2",
+                "symfony/event-dispatcher-contracts": "^2|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4"
+                "symfony/dependency-injection": "<5.4"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0"
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/http-foundation": "^4.4|^5.0|^6.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
-                "symfony/stopwatch": "^4.4|^5.0|^6.0"
+                "symfony/stopwatch": "^5.4|^6.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -1362,7 +1286,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.0.9"
             },
             "funding": [
                 {
@@ -1378,24 +1302,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-05T16:45:39+00:00"
+            "time": "2022-05-05T16:45:52+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.5.2",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "f98b54df6ad059855739db6fcbc2d36995283fe1"
+                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/f98b54df6ad059855739db6fcbc2d36995283fe1",
-                "reference": "f98b54df6ad059855739db6fcbc2d36995283fe1",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7bc61cc2db649b4637d331240c5346dcc7708051",
+                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "psr/event-dispatcher": "^1"
             },
             "suggest": {
@@ -1404,7 +1328,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1441,7 +1365,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.5.2"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -1457,7 +1381,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1790,85 +1714,6 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
             "name": "symfony/polyfill-php80",
             "version": "v1.27.0",
             "source": {
@@ -1953,29 +1798,36 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.2",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0"
+                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/191afdcb5804db960d26d8566b7e9a2843cab3a0",
-                "reference": "191afdcb5804db960d26d8566b7e9a2843cab3a0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
+                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": ">=8.0.2",
+                "psr/container": "^2.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
             },
             "suggest": {
-                "psr/container": "",
                 "symfony/service-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-main": "3.0-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -2008,40 +1860,53 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v1.1.2"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.0.2"
             },
-            "time": "2019-05-28T07:50:59+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-30T19:17:58+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.15",
+            "version": "v6.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "571334ce9f687e3e6af72db4d3b2a9431e4fd9ed"
+                "reference": "51ac0fa0ccf132a00519b87c97e8f775fa14e771"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/571334ce9f687e3e6af72db4d3b2a9431e4fd9ed",
-                "reference": "571334ce9f687e3e6af72db4d3b2a9431e4fd9ed",
+                "url": "https://api.github.com/repos/symfony/string/zipball/51ac0fa0ccf132a00519b87c97e8f775fa14e771",
+                "reference": "51ac0fa0ccf132a00519b87c97e8f775fa14e771",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": ">=3.0"
+                "symfony/translation-contracts": "<2.0"
             },
             "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0|^6.0",
-                "symfony/http-client": "^4.4|^5.0|^6.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/http-client": "^5.4|^6.0",
+                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -2080,7 +1945,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.15"
+                "source": "https://github.com/symfony/string/tree/v6.0.15"
             },
             "funding": [
                 {
@@ -2096,7 +1961,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-05T15:16:54+00:00"
+            "time": "2022-10-10T09:34:08+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2399,16 +2264,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
+                "reference": "4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb",
+                "reference": "4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb",
                 "shasum": ""
             },
             "require": {
@@ -2450,7 +2315,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.0"
+                "source": "https://github.com/composer/pcre/tree/3.0.2"
             },
             "funding": [
                 {
@@ -2466,7 +2331,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-17T09:50:14+00:00"
+            "time": "2022-11-03T20:24:16+00:00"
         },
         {
             "name": "composer/semver",
@@ -3117,31 +2982,30 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.13.0",
+            "version": "3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "66a6d03c381f6c9f1dd988bf8244f9afb9380d76"
+                "reference": "63b66bd4b696f024f42616b9d95cdb10e5109c27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/66a6d03c381f6c9f1dd988bf8244f9afb9380d76",
-                "reference": "66a6d03c381f6c9f1dd988bf8244f9afb9380d76",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/63b66bd4b696f024f42616b9d95cdb10e5109c27",
+                "reference": "63b66bd4b696f024f42616b9d95cdb10e5109c27",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0.0 || ~8.1.0"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-coding-standard": "^2.4.0",
                 "phpbench/phpbench": "^1.2.6",
-                "phpstan/phpdoc-parser": "^0.5.4",
-                "phpunit/phpunit": "^9.5.23",
+                "phpunit/phpunit": "^9.5.25",
                 "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.26"
+                "vimeo/psalm": "^4.28"
             },
             "type": "library",
             "autoload": {
@@ -3173,7 +3037,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-08-24T13:56:50+00:00"
+            "time": "2022-10-10T19:10:24+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3716,16 +3580,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.19",
+            "version": "9.2.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559"
+                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c77b56b63e3d2031bd8997fcec43c1925ae46559",
-                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
+                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
                 "shasum": ""
             },
             "require": {
@@ -3781,7 +3645,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.19"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.18"
             },
             "funding": [
                 {
@@ -3789,7 +3653,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-11-18T07:47:47+00:00"
+            "time": "2022-10-27T13:35:33+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -5592,7 +5456,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.99"
+        "php": "8.0.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d466f0f36d7f5c9cd987004b81636132",
+    "content-hash": "17b834c58a1083c2d82cb6f636f747fe",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -5452,7 +5452,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0"
+        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/composer.lock
+++ b/composer.lock
@@ -194,16 +194,16 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.21.0",
+            "version": "2.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "e5b6419fea007b8b4a71034edc8ec96c88d4c57d"
+                "reference": "df8c7f9e11d854269f4aa7c06ffa38caa42e4405"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/e5b6419fea007b8b4a71034edc8ec96c88d4c57d",
-                "reference": "e5b6419fea007b8b4a71034edc8ec96c88d4c57d",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/df8c7f9e11d854269f4aa7c06ffa38caa42e4405",
+                "reference": "df8c7f9e11d854269f4aa7c06ffa38caa42e4405",
                 "shasum": ""
             },
             "require": {
@@ -287,7 +287,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-11-11T09:01:24+00:00"
+            "time": "2022-11-22T05:54:54+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -500,16 +500,16 @@
         },
         {
             "name": "mezzio/mezzio",
-            "version": "3.13.0",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio.git",
-                "reference": "a9d6f7d6e45c37180059e5a4731a225ceb80cef1"
+                "reference": "cbb044afda55f8d4a9b395d5aa37c98d1e1e5369"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/a9d6f7d6e45c37180059e5a4731a225ceb80cef1",
-                "reference": "a9d6f7d6e45c37180059e5a4731a225ceb80cef1",
+                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/cbb044afda55f8d4a9b395d5aa37c98d1e1e5369",
+                "reference": "cbb044afda55f8d4a9b395d5aa37c98d1e1e5369",
                 "shasum": ""
             },
             "require": {
@@ -543,9 +543,9 @@
                 "mezzio/mezzio-fastroute": "^3.7",
                 "mezzio/mezzio-laminasrouter": "^3.7",
                 "mockery/mockery": "^1.5.1",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17",
-                "vimeo/psalm": "^4.28"
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18",
+                "vimeo/psalm": "^5.0.0"
             },
             "suggest": {
                 "filp/whoops": "^2.1 to use the Whoops error handler",
@@ -604,7 +604,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-11T08:04:06+00:00"
+            "time": "2022-12-05T09:40:08+00:00"
         },
         {
             "name": "mezzio/mezzio-router",
@@ -1128,16 +1128,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.15",
+            "version": "v6.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "b0b910724a0a0326b4481e4f8a30abb2dd442efb"
+                "reference": "be294423f337dda97c810733138c0caec1bb0575"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/b0b910724a0a0326b4481e4f8a30abb2dd442efb",
-                "reference": "b0b910724a0a0326b4481e4f8a30abb2dd442efb",
+                "url": "https://api.github.com/repos/symfony/console/zipball/be294423f337dda97c810733138c0caec1bb0575",
+                "reference": "be294423f337dda97c810733138c0caec1bb0575",
                 "shasum": ""
             },
             "require": {
@@ -1203,7 +1203,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.15"
+                "source": "https://github.com/symfony/console/tree/v6.0.16"
             },
             "funding": [
                 {
@@ -1219,7 +1219,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-26T21:42:20+00:00"
+            "time": "2022-11-25T18:58:46+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2264,16 +2264,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb"
+                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb",
-                "reference": "4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
                 "shasum": ""
             },
             "require": {
@@ -2315,7 +2315,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.0.2"
+                "source": "https://github.com/composer/pcre/tree/3.1.0"
             },
             "funding": [
                 {
@@ -2331,7 +2331,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T20:24:16+00:00"
+            "time": "2022-11-17T09:50:14+00:00"
         },
         {
             "name": "composer/semver",
@@ -2982,16 +2982,16 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.15.0",
+            "version": "3.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "63b66bd4b696f024f42616b9d95cdb10e5109c27"
+                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/63b66bd4b696f024f42616b9d95cdb10e5109c27",
-                "reference": "63b66bd4b696f024f42616b9d95cdb10e5109c27",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
                 "shasum": ""
             },
             "require": {
@@ -3002,10 +3002,10 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.6",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.28"
+                "phpbench/phpbench": "^1.2.7",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
+                "vimeo/psalm": "^5.0.0"
             },
             "type": "library",
             "autoload": {
@@ -3037,7 +3037,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-10T19:10:24+00:00"
+            "time": "2022-12-03T18:48:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -3100,16 +3100,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.0.0",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d"
+                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
-                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
+                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
                 "shasum": ""
             },
             "require": {
@@ -3145,9 +3145,9 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.0.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.1.0"
             },
-            "time": "2020-12-01T19:48:11+00:00"
+            "time": "2022-12-08T20:46:14+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3580,16 +3580,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.18",
+            "version": "9.2.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a"
+                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
-                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c77b56b63e3d2031bd8997fcec43c1925ae46559",
+                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559",
                 "shasum": ""
             },
             "require": {
@@ -3645,7 +3645,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.18"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.19"
             },
             "funding": [
                 {
@@ -3653,7 +3653,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-27T13:35:33+00:00"
+            "time": "2022-11-18T07:47:47+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3898,16 +3898,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.26",
+            "version": "9.5.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2"
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/851867efcbb6a1b992ec515c71cdcf20d895e9d2",
-                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
                 "shasum": ""
             },
             "require": {
@@ -3980,7 +3980,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.26"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
             },
             "funding": [
                 {
@@ -3996,20 +3996,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-28T06:00:21+00:00"
+            "time": "2022-12-09T07:31:23+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
-            "version": "0.18.3",
+            "version": "0.18.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
-                "reference": "057c1cdf7546c1e427f6fd83b635d0cc18c252bf"
+                "reference": "e4ab3096653d9eb6f6d0ea5f4461898d59ae4dbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/057c1cdf7546c1e427f6fd83b635d0cc18c252bf",
-                "reference": "057c1cdf7546c1e427f6fd83b635d0cc18c252bf",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/e4ab3096653d9eb6f6d0ea5f4461898d59ae4dbc",
+                "reference": "e4ab3096653d9eb6f6d0ea5f4461898d59ae4dbc",
                 "shasum": ""
             },
             "require": {
@@ -4017,7 +4017,7 @@
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "ext-simplexml": "*",
                 "php": "^7.1 || ^8.0",
-                "vimeo/psalm": "dev-master || dev-4.x || ^4.5 || ^5@beta"
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.7.1 || ^5@beta || ^5.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.5"
@@ -4054,9 +4054,9 @@
             "description": "Psalm plugin for PHPUnit",
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
-                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.18.3"
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.18.4"
             },
-            "time": "2022-11-03T18:17:28+00:00"
+            "time": "2022-12-03T07:47:07+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,27 +17,4 @@
 
     <!-- Include all rules from Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard" />
-
-    <rule ref="Generic.Files.LineLength.TooLong">
-        <exclude-pattern>/test/Log/AccessLogFactoryTest.php</exclude-pattern>
-        <exclude-pattern>/test/Log/AccessLogFormatterTest.php</exclude-pattern>
-        <exclude-pattern>/test/Log/SwooleLoggerFactoryTest.php</exclude-pattern>
-        <exclude-pattern>/test/StaticResourceHandler/IntegrationMappedTest.php</exclude-pattern>
-        <exclude-pattern>/test/StaticResourceHandler/IntegrationTest.php</exclude-pattern>
-        <exclude-pattern>/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php</exclude-pattern>
-        <exclude-pattern>/test/SwooleRequestHandlerRunnerFactoryTest.php</exclude-pattern>
-    </rule>
-
-    <rule ref="WebimpressCodingStandard.Functions.Param.InconsistentVariadic">
-        <exclude-pattern>/src/SwooleRequestHandlerRunner.php</exclude-pattern>
-        <exclude-pattern>/src/Task/*Task.php</exclude-pattern>
-        <exclude-pattern>/test/TestAsset/CallableObject.php</exclude-pattern>
-        <exclude-pattern>/test/TestAsset/ClassWithCallbacks.php</exclude-pattern>
-    </rule>
-
-    <rule ref="Generic.Files.LineLength.TooLong">
-        <exclude-pattern>/src/ConfigProvider.php</exclude-pattern>
-        <exclude-pattern>/test/Task/TaskEventDispatchListener*Test.php</exclude-pattern>
-        <exclude-pattern>/test/Task/TaskInvokerListener*Test.php</exclude-pattern>
-    </rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,4 +17,26 @@
 
     <!-- Include all rules from Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard" />
+
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>/src/ConfigProvider.php</exclude-pattern>
+        <exclude-pattern>/test/HttpServerFactoryTest.php</exclude-pattern>
+        <exclude-pattern>/test/Log/AccessLogFactoryTest.php</exclude-pattern>
+        <exclude-pattern>/test/Log/AccessLogFormatterTest.php</exclude-pattern>
+        <exclude-pattern>/test/Log/SwooleLoggerFactoryTest.php</exclude-pattern>
+        <exclude-pattern>/test/StaticResourceHandler/IntegrationMappedTest.php</exclude-pattern>
+        <exclude-pattern>/test/StaticResourceHandler/IntegrationTest.php</exclude-pattern>
+        <exclude-pattern>/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php</exclude-pattern>
+        <exclude-pattern>/test/StaticResourceHandler/OptionsMiddlewareTest.php</exclude-pattern>
+        <exclude-pattern>/test/SwooleRequestHandlerRunnerFactoryTest.php</exclude-pattern>
+        <exclude-pattern>/test/Task/TaskEventDispatchListener*Test.php</exclude-pattern>
+        <exclude-pattern>/test/Task/TaskInvokerListener*Test.php</exclude-pattern>
+    </rule>
+
+    <rule ref="WebimpressCodingStandard.Functions.Param.InconsistentVariadic">
+        <exclude-pattern>/src/SwooleRequestHandlerRunner.php</exclude-pattern>
+        <exclude-pattern>/src/Task/*Task.php</exclude-pattern>
+        <exclude-pattern>/test/TestAsset/CallableObject.php</exclude-pattern>
+        <exclude-pattern>/test/TestAsset/ClassWithCallbacks.php</exclude-pattern>        
+    </rule>
 </ruleset>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,128 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="src/AbstractStaticResourceHandlerFactory.php">
-    <MixedArgument occurrences="3">
-      <code>$compressionLevel</code>
-      <code>$config['etag-type'] ?? StaticResourceHandler\ETagMiddleware::ETAG_VALIDATION_WEAK</code>
-      <code>$config['type-map'] ?? StaticResourceHandler\ContentTypeFilterMiddleware::TYPE_MAP_DEFAULT</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$directives['cache-control']</code>
-    </MixedArrayAccess>
     <MixedArrayOffset occurrences="1">
       <code>$cacheControlDirectives[$regex]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="6">
-      <code>$cacheControlDirectives[$regex]</code>
-      <code>$clearStatCacheInterval</code>
-      <code>$compressionLevel</code>
-      <code>$directiveList</code>
-      <code>$directives</code>
-      <code>$regex</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Command/IsRunningTrait.php">
-    <InvalidArgument occurrences="2">
-      <code>0</code>
-      <code>0</code>
-    </InvalidArgument>
-    <MixedMethodCall occurrences="1">
-      <code>read</code>
-    </MixedMethodCall>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;pidManager</code>
-    </UndefinedThisPropertyFetch>
-  </file>
-  <file src="src/Command/ReloadCommand.php">
-    <PossiblyNullArgument occurrences="2">
-      <code>StartCommand::$defaultName</code>
-      <code>StopCommand::$defaultName</code>
-    </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="1">
-      <code>find</code>
-    </PossiblyNullReference>
-  </file>
-  <file src="src/Command/ReloadCommandFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$mode</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$config['mezzio-swoole']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
-      <code>$config</code>
-      <code>$mode</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Command/StartCommand.php">
-    <MixedAssignment occurrences="1">
-      <code>$server</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="1">
-      <code>set</code>
-    </MixedMethodCall>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;pidManager</code>
-    </UndefinedThisPropertyAssignment>
-  </file>
-  <file src="src/Command/StatusCommandFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$container-&gt;get(PidManager::class)</code>
-    </MixedArgument>
-  </file>
-  <file src="src/Command/StopCommandFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$container-&gt;get(PidManager::class)</code>
-    </MixedArgument>
-  </file>
-  <file src="src/Event/ServerStartListenerFactory.php">
-    <MixedAssignment occurrences="1">
-      <code>$config</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Event/SwooleListenerProviderFactory.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$config['mezzio-swoole']['swoole-http-server']['listeners']</code>
-    </MixedArrayAccess>
-  </file>
-  <file src="src/Event/WorkerStartListenerFactory.php">
-    <MixedAssignment occurrences="1">
-      <code>$config</code>
-    </MixedAssignment>
   </file>
   <file src="src/HotCodeReload/FileWatcher/InotifyFileWatcher.php">
-    <MixedArgument occurrences="1">
-      <code>IN_MODIFY</code>
-    </MixedArgument>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;filePathByWd[$wd]</code>
-    </MixedArrayOffset>
-    <MixedAssignment occurrences="1">
-      <code>$wd</code>
-    </MixedAssignment>
     <UndefinedConstant occurrences="1">
       <code>IN_MODIFY</code>
     </UndefinedConstant>
   </file>
   <file src="src/HttpServerFactory.php">
-    <MixedArgument occurrences="2">
-      <code>$validProtocols</code>
-      <code>static::MODES</code>
-    </MixedArgument>
     <MixedArrayAssignment occurrences="2">
       <code>$validProtocols[]</code>
       <code>$validProtocols[]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="8">
-      <code>$enableCoroutine</code>
-      <code>$host</code>
-      <code>$mode</code>
-      <code>$port</code>
-      <code>$protocol</code>
-      <code>$validProtocols</code>
-      <code>$validProtocols[]</code>
-      <code>$validProtocols[]</code>
-    </MixedAssignment>
   </file>
   <file src="src/Log/AccessLogDataMap.php">
     <InvalidOperand occurrences="3">
@@ -130,50 +22,10 @@
       <code>$begin</code>
       <code>$begin</code>
     </InvalidOperand>
-    <MixedArgument occurrences="5">
-      <code>$header</code>
-      <code>$header</code>
-      <code>$line</code>
-      <code>$query</code>
-      <code>$this-&gt;request-&gt;header['host'] ?? ''</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="5">
-      <code>$this-&gt;request-&gt;cookie[$name]</code>
-      <code>$this-&gt;request-&gt;header[$header]</code>
-      <code>$this-&gt;request-&gt;header['host']</code>
-      <code>$this-&gt;request-&gt;header[strtolower($name)]</code>
-      <code>$this-&gt;request-&gt;server[strtolower($key)]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
-      <code>$bodySize</code>
-      <code>$firstLineSize</code>
-      <code>$header</code>
-      <code>$headersSize</code>
-      <code>$line</code>
-      <code>$query</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="6">
-      <code>?int</code>
-      <code>?int</code>
-      <code>int</code>
-      <code>string</code>
-      <code>string</code>
-      <code>string</code>
-    </MixedInferredReturnType>
     <MixedOperand occurrences="2">
       <code>$firstLineSize</code>
       <code>$strlen($firstLine)</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="6">
-      <code>$firstLineSize + 2 + $headerSize + 4 + $bodySize</code>
-      <code>$strlen($firstLine) + 2 + $headersSize + 4 + $bodySize</code>
-      <code>$strlen(implode("\r\n", $headers))</code>
-      <code>$this-&gt;request-&gt;cookie[$name] ?? '-'</code>
-      <code>$this-&gt;request-&gt;header[$header]</code>
-      <code>$this-&gt;request-&gt;header[strtolower($name)] ?? '-'</code>
-    </MixedReturnStatement>
     <PossiblyInvalidArgument occurrences="1">
       <code>$time</code>
     </PossiblyInvalidArgument>
@@ -189,112 +41,23 @@
       <code>getHeaderSize</code>
     </PossiblyNullReference>
   </file>
-  <file src="src/Log/AccessLogFactory.php">
-    <MixedArgument occurrences="3">
-      <code>$config</code>
-      <code>$config['format'] ?? AccessLogFormatter::FORMAT_COMMON</code>
-      <code>$config['use-hostname-lookups'] ?? false</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$config['mezzio-swoole']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
-      <code>$config</code>
-      <code>$config</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>AccessLogFormatterInterface</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$container-&gt;get(AccessLogFormatterInterface::class)</code>
-    </MixedReturnStatement>
-  </file>
   <file src="src/Log/AccessLogFormatter.php">
     <InvalidScalarArgument occurrences="3">
       <code>'-'</code>
       <code>'-'</code>
     </InvalidScalarArgument>
   </file>
-  <file src="src/Log/LoggerResolvingTrait.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>LoggerInterface</code>
-    </MixedInferredReturnType>
-  </file>
-  <file src="src/Log/StdoutLogger.php">
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$value</code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
-      <code>$value</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/Log/SwooleLoggerFactory.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$config['mezzio-swoole']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$config</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>LoggerInterface</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$container-&gt;get($loggerConfig['logger-name'])</code>
-      <code>$container-&gt;has(LoggerInterface::class) ? $container-&gt;get(LoggerInterface::class) : new StdoutLogger()</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/PidManagerFactory.php">
-    <MixedArgument occurrences="1"/>
-    <MixedArrayAccess occurrences="1">
-      <code>$config['mezzio-swoole']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$config</code>
-    </MixedAssignment>
-  </file>
   <file src="src/ServerRequestSwooleFactory.php">
     <DeprecatedFunction occurrences="1">
       <code>marshalUriFromSapi($server, $stripXForwardedHeaders($headers))</code>
     </DeprecatedFunction>
-    <MixedArgument occurrences="6">
-      <code>$cookie</code>
-      <code>$files</code>
-      <code>$get</code>
-      <code>$headers</code>
-      <code>$post</code>
-      <code>$server</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="7">
-      <code>$cookie</code>
-      <code>$files</code>
-      <code>$get</code>
-      <code>$headers</code>
-      <code>$post</code>
-      <code>$requestFilter</code>
-      <code>$server</code>
-    </MixedAssignment>
   </file>
   <file src="src/StaticMappedResourceHandler.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$request-&gt;server['request_uri']</code>
-    </MixedArrayAccess>
     <MixedPropertyTypeCoercion occurrences="1">
       <code>$middleware</code>
     </MixedPropertyTypeCoercion>
   </file>
-  <file src="src/StaticMappedResourceHandlerFactory.php">
-    <MixedArgument occurrences="2">
-      <code>$config</code>
-      <code>$container-&gt;get(StaticResourceHandler\FileLocationRepositoryInterface::class)</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$config</code>
-    </MixedAssignment>
-  </file>
   <file src="src/StaticResourceHandler.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$request-&gt;server['request_uri']</code>
-    </MixedArrayAccess>
     <MixedOperand occurrences="1">
       <code>$request-&gt;server['request_uri']</code>
     </MixedOperand>
@@ -303,370 +66,40 @@
     </MixedPropertyTypeCoercion>
   </file>
   <file src="src/StaticResourceHandler/CacheControlMiddleware.php">
-    <MissingClosureParamType occurrences="1">
-      <code>$directive</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="1">
-      <code>$request-&gt;server['request_uri']</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
-      <code>$regex</code>
-      <code>$regex</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="1">
-      <code>$request-&gt;server['request_uri']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$response</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
-      <code>addHeader</code>
-    </MixedMethodCall>
     <MixedPropertyTypeCoercion occurrences="1">
       <code>$cacheControlDirectives</code>
     </MixedPropertyTypeCoercion>
-    <MixedReturnStatement occurrences="1">
-      <code>$response</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/StaticResourceHandler/ClearStatCacheMiddleware.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$next($request, $filename)</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/StaticResourceHandler/ContentTypeFilterMiddleware.php">
-    <MixedAssignment occurrences="1">
-      <code>$response</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
-      <code>addHeader</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>$response</code>
-    </MixedReturnStatement>
   </file>
   <file src="src/StaticResourceHandler/ETagMiddleware.php">
-    <MixedArgument occurrences="3">
-      <code>$ifMatch ?: $ifNoneMatch</code>
-      <code>$request-&gt;server['request_uri']</code>
-      <code>$response</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$request-&gt;header['if-match']</code>
-      <code>$request-&gt;header['if-none-match']</code>
-      <code>$request-&gt;server['request_uri']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$ifMatch</code>
-      <code>$ifNoneMatch</code>
-      <code>$response</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
     <MixedPropertyTypeCoercion occurrences="1">
       <code>$etagDirectives</code>
     </MixedPropertyTypeCoercion>
-    <MixedReturnStatement occurrences="1">
-      <code>$response</code>
-    </MixedReturnStatement>
   </file>
   <file src="src/StaticResourceHandler/FileLocationRepository.php">
-    <MixedArgument occurrences="3">
-      <code>$d</code>
-      <code>$directory</code>
-      <code>$this-&gt;mappedDocRoots[$prefix]</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="3">
-      <code>$prefix</code>
-      <code>$prefix</code>
-      <code>$prefix</code>
-    </MixedArgumentTypeCoercion>
     <MixedArrayAssignment occurrences="1">
       <code>$this-&gt;mappedDocRoots[$prefix][]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
-      <code>$d</code>
-      <code>$directories</code>
-      <code>$directory</code>
-    </MixedAssignment>
     <MixedOperand occurrences="1">
       <code>$directory</code>
     </MixedOperand>
   </file>
-  <file src="src/StaticResourceHandler/FileLocationRepositoryFactory.php">
-    <MixedArgument occurrences="4">
-      <code>$configDocRoots</code>
-      <code>$configDocRoots</code>
-      <code>$configMappedDocRoots</code>
-      <code>$configMappedDocRoots</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$config['document-root']</code>
-      <code>$config['mapped-document-roots']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
-      <code>$config</code>
-      <code>$configDocRoots</code>
-      <code>$configMappedDocRoots</code>
-    </MixedAssignment>
-  </file>
   <file src="src/StaticResourceHandler/GzipMiddleware.php">
-    <InvalidScalarArgument occurrences="3">
-      <code>true</code>
-      <code>true</code>
-      <code>true</code>
-    </InvalidScalarArgument>
-    <MixedArgument occurrences="1">
-      <code>$request-&gt;header['accept-encoding']</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$request-&gt;header['accept-encoding']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$response</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
-      <code>setContentLength</code>
-      <code>setResponseContentCallback</code>
-    </MixedMethodCall>
     <MixedOperand occurrences="1">
       <code>$countBytes($line)</code>
     </MixedOperand>
-    <MixedReturnStatement occurrences="3">
-      <code>$response</code>
-      <code>$response</code>
-      <code>$response</code>
-    </MixedReturnStatement>
     <UnusedFunctionCall occurrences="1">
       <code>stream_filter_append</code>
     </UnusedFunctionCall>
   </file>
-  <file src="src/StaticResourceHandler/HeadMiddleware.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$server['request_method']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
-      <code>$response</code>
-      <code>$server</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
-      <code>disableContent</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$response</code>
-      <code>$response</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/StaticResourceHandler/LastModifiedMiddleware.php">
-    <MixedArgument occurrences="2">
-      <code>$ifModifiedSince</code>
-      <code>$request-&gt;server['request_uri']</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$request-&gt;header['if-modified-since']</code>
-      <code>$request-&gt;server['request_uri']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
-      <code>$ifModifiedSince</code>
-      <code>$response</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
-      <code>addHeader</code>
-      <code>disableContent</code>
-      <code>setStatus</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$response</code>
-      <code>$response</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/StaticResourceHandler/MethodNotAllowedMiddleware.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$server['request_method']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$server</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$next($request, $filename)</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/StaticResourceHandler/MiddlewareQueue.php">
-    <MixedPropertyTypeCoercion occurrences="1">
-      <code>$middleware</code>
-    </MixedPropertyTypeCoercion>
-  </file>
-  <file src="src/StaticResourceHandler/OptionsMiddleware.php">
-    <MixedArrayAccess occurrences="1">
-      <code>$server['request_method']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
-      <code>$response</code>
-      <code>$server</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>StaticResourceResponse</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
-      <code>addHeader</code>
-      <code>disableContent</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$response</code>
-      <code>$response</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/StaticResourceHandler/StaticResourceResponse.php">
-    <InvalidArgument occurrences="2">
-      <code>$this-&gt;status</code>
-      <code>true</code>
-    </InvalidArgument>
-    <InvalidScalarArgument occurrences="1">
-      <code>true</code>
-    </InvalidScalarArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>int</code>
-    </MixedInferredReturnType>
-    <MixedPropertyTypeCoercion occurrences="1">
-      <code>$headers</code>
-    </MixedPropertyTypeCoercion>
-    <MixedReturnStatement occurrences="1">
-      <code>$strlen(implode("\r\n", $headers))</code>
-    </MixedReturnStatement>
-  </file>
-  <file src="src/StaticResourceHandler/ValidateRegexTrait.php">
-    <MixedArgument occurrences="1">
-      <code>$regex</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$regex</code>
-    </MixedAssignment>
-  </file>
-  <file src="src/StaticResourceHandlerFactory.php">
-    <MixedArgument occurrences="2">
-      <code>$config</code>
-      <code>$config['document-root'] ?? getcwd() . '/public'</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$config['document-root']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$config</code>
-    </MixedAssignment>
-  </file>
   <file src="src/SwooleEmitter.php">
-    <InvalidArgument occurrences="4">
-      <code>$cookie-&gt;getExpires()</code>
-      <code>$cookie-&gt;getHttpOnly()</code>
-      <code>$cookie-&gt;getSecure()</code>
-      <code>$response-&gt;getStatusCode()</code>
-    </InvalidArgument>
-    <MixedArgument occurrences="1">
-      <code>static::CHUNK_SIZE</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$name</code>
-    </MixedArgumentTypeCoercion>
-    <PossiblyNullArgument occurrences="1">
-      <code>$cookie-&gt;getValue()</code>
-    </PossiblyNullArgument>
     <PossiblyNullReference occurrences="1">
       <code>asString</code>
     </PossiblyNullReference>
-    <TooManyArguments occurrences="1">
-      <code>cookie</code>
-    </TooManyArguments>
-  </file>
-  <file src="src/SwooleStream.php">
-    <InvalidToString occurrences="1">
-      <code>string</code>
-    </InvalidToString>
-    <NullableReturnStatement occurrences="1">
-      <code>$this-&gt;body</code>
-    </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="2">
-      <code>$this-&gt;body</code>
-      <code>$this-&gt;body</code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="src/Task/DeferredListener.php">
-    <InvalidCast occurrences="1">
-      <code>new Task($this-&gt;listener, $event)</code>
-    </InvalidCast>
-  </file>
-  <file src="src/Task/DeferredServiceListener.php">
-    <InvalidCast occurrences="1">
-      <code>new ServiceBasedTask($this-&gt;serviceName, $event)</code>
-    </InvalidCast>
   </file>
   <file src="src/Task/Task.php">
     <MixedPropertyTypeCoercion occurrences="1">
       <code>$payload</code>
     </MixedPropertyTypeCoercion>
-  </file>
-  <file src="test/AssertResponseTrait.php">
-    <MixedArgument occurrences="7">
-      <code>$actual</code>
-      <code>$headers</code>
-      <code>$headers</code>
-      <code>$headers</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$headers[$header]</code>
-      <code>$headers[$header]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="5">
-      <code>$headers</code>
-      <code>$headers</code>
-      <code>$headers</code>
-      <code>$headers</code>
-      <code>$value</code>
-    </MixedAssignment>
-  </file>
-  <file src="test/AttributeAssertionTrait.php">
-    <MixedArgument occurrences="1">
-      <code>$expected</code>
-    </MixedArgument>
-  </file>
-  <file src="test/Command/StartCommandTest.php">
-    <MixedArgument occurrences="2">
-      <code>$command</code>
-      <code>$command</code>
-    </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>iterable</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="4">
-      <code>expects</code>
-      <code>expects</code>
-      <code>method</code>
-      <code>method</code>
-    </MixedMethodCall>
   </file>
   <file src="test/Command/StopCommandTest.php">
     <InternalProperty occurrences="3">
@@ -679,153 +112,16 @@
       <code>assertTrue</code>
     </TypeDoesNotContainType>
   </file>
-  <file src="test/Command/TestAsset/config/pipeline.php">
-    <UnusedClosureParam occurrences="3">
-      <code>$app</code>
-      <code>$container</code>
-      <code>$factory</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/Command/TestAsset/config/routes.php">
-    <UnusedClosureParam occurrences="3">
-      <code>$app</code>
-      <code>$container</code>
-      <code>$factory</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/Event/EventDispatcherTest.php">
-    <UnusedClosureParam occurrences="2">
-      <code>$event</code>
-      <code>$event</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/Event/RequestHandlerRequestListenerFactoryTest.php">
-    <UnusedClosureParam occurrences="2">
-      <code>$e</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/Event/RequestHandlerRequestListenerTest.php">
-    <UnusedClosureParam occurrences="2">
-      <code>$response</code>
-      <code>$swooleRequest</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/Event/SwooleListenerProviderFactoryTest.php">
-    <UnusedClosureParam occurrences="1">
-      <code>$event</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/Event/SwooleListenerProviderTest.php">
-    <UnusedClosureParam occurrences="3">
-      <code>$e</code>
-      <code>$e</code>
-      <code>$e</code>
-    </UnusedClosureParam>
-  </file>
   <file src="test/HotCodeReload/FileWatcher/InotifyFileWatcherTest.php">
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;file</code>
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="test/HttpServerFactoryTest.php">
-    <InvalidScalarArgument occurrences="2">
-      <code>0</code>
-      <code>0</code>
-    </InvalidScalarArgument>
     <LessSpecificReturnStatement occurrences="1">
       <code>$validTypes</code>
     </LessSpecificReturnStatement>
-    <MissingClosureParamType occurrences="4">
-      <code>$clientInfo</code>
-      <code>$data</code>
-      <code>$rep</code>
-      <code>$req</code>
-    </MissingClosureParamType>
     <MoreSpecificReturnType occurrences="1"/>
-    <UnusedClosureParam occurrences="5">
-      <code>$clientInfo</code>
-      <code>$data</code>
-      <code>$rep</code>
-      <code>$req</code>
-      <code>$server</code>
-    </UnusedClosureParam>
-    <UnusedFunctionCall occurrences="3">
-      <code>go</code>
-      <code>go</code>
-      <code>go</code>
-    </UnusedFunctionCall>
-  </file>
-  <file src="test/Log/LoggerFactoryHelperTrait.php">
-    <MixedAssignment occurrences="1">
-      <code>$value</code>
-    </MixedAssignment>
-  </file>
-  <file src="test/StaticResourceHandler/CacheControlMiddlewareTest.php">
-    <UnusedClosureParam occurrences="4">
-      <code>$filename</code>
-      <code>$filename</code>
-      <code>$request</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php">
-    <UnusedClosureParam occurrences="4">
-      <code>$filename</code>
-      <code>$filename</code>
-      <code>$request</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/StaticResourceHandler/ETagMiddlewareTest.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>iterable</code>
-    </MixedInferredReturnType>
-    <UnusedClosureParam occurrences="2">
-      <code>$filename</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/StaticResourceHandler/GzipMiddlewareTest.php">
-    <UnusedClosureParam occurrences="4">
-      <code>$filename</code>
-      <code>$filename</code>
-      <code>$request</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/StaticResourceHandler/HeadMiddlewareTest.php">
-    <UnusedClosureParam occurrences="2">
-      <code>$filename</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/StaticResourceHandler/LastModifiedMiddlewareTest.php">
-    <UnusedClosureParam occurrences="2">
-      <code>$filename</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php">
-    <UnusedClosureParam occurrences="4">
-      <code>$filename</code>
-      <code>$filename</code>
-      <code>$request</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/StaticResourceHandler/OptionsMiddlewareTest.php">
-    <UnusedClosureParam occurrences="4">
-      <code>$filename</code>
-      <code>$filename</code>
-      <code>$request</code>
-      <code>$request</code>
-    </UnusedClosureParam>
-  </file>
-  <file src="test/StaticResourceHandler/StaticResourceResponseTest.php">
-    <UnusedClosureParam occurrences="1">
-      <code>$response</code>
-    </UnusedClosureParam>
   </file>
   <file src="test/TestAsset/CallableObject.php">
     <MixedReturnTypeCoercion occurrences="2">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -38,6 +38,18 @@
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
             </errorLevel>
         </InternalMethod>
+
+        <MissingClosureParamType errorLevel="suppress"/>
+        <MixedArgument errorLevel="suppress"/>
+        <MixedArgumentTypeCoercion errorLevel="suppress"/>
+        <MixedArrayAccess errorLevel="suppress"/>
+        <MixedAssignment errorLevel="suppress"/>
+        <MixedInferredReturnType errorLevel="suppress"/>
+        <MixedMethodCall errorLevel="suppress"/>
+        <MixedReturnStatement errorLevel="suppress"/>
+        <PossiblyNullArgument errorLevel="suppress"/>
+        <PropertyNotSetInConstructor errorLevel="suppress"/>
+        <UnusedClosureParam errorLevel="suppress"/>
     </issueHandlers>
 
     <plugins>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -43,4 +43,63 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <stubs>
+        <file name="vendor/swoole/ide-helper/src/swoole/constants.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/functions.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/shortnames.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Atomic.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Atomic/Long.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Client.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Client/Exception.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Connection/Iterator.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Channel.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Client.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Context.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Curl/Exception.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Http/Client.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Http/Client/Exception.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Http/Server.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Http2/Client.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Iterator.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/MySQL.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/MySQL/Exception.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/MySQL/Statement.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/PostgreSQL.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/PostgreSQLStatement.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Redis.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Scheduler.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Socket.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Socket/Exception.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/System.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Error.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Event.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Exception.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/ExitException.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Http/Request.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Http/Response.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Http/Server.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Http2/Request.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Http2/Response.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Lock.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/NameResolver/Context.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Process.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Process/Pool.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Redis/Server.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Runtime.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Server.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Server/Event.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Server/Packet.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Server/PipeMessage.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Server/Port.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Server/StatusInfo.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Server/Task.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Server/TaskResult.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Table.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Timer.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Timer/Iterator.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/WebSocket/CloseFrame.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/WebSocket/Frame.php" />
+        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/WebSocket/Server.php" />
+    </stubs>
 </psalm>

--- a/src/AbstractStaticResourceHandlerFactory.php
+++ b/src/AbstractStaticResourceHandlerFactory.php
@@ -55,7 +55,6 @@ abstract class AbstractStaticResourceHandlerFactory
      */
     protected function configureMiddleware(array $config): array
     {
-        /** @var array{type-map:array<string,string>} $config */
         $middleware = [
             new ContentTypeFilterMiddleware(
                 $config['type-map'] ?? ContentTypeFilterMiddleware::TYPE_MAP_DEFAULT

--- a/src/AbstractStaticResourceHandlerFactory.php
+++ b/src/AbstractStaticResourceHandlerFactory.php
@@ -55,6 +55,7 @@ abstract class AbstractStaticResourceHandlerFactory
      */
     protected function configureMiddleware(array $config): array
     {
+        /** @var array{type-map:array<string,string>} $config */
         $middleware = [
             new ContentTypeFilterMiddleware(
                 $config['type-map'] ?? ContentTypeFilterMiddleware::TYPE_MAP_DEFAULT

--- a/src/Command/IsRunningTrait.php
+++ b/src/Command/IsRunningTrait.php
@@ -20,8 +20,7 @@ trait IsRunningTrait
     public function isRunning(): bool
     {
         /**
-         * @psalm-suppress UnnecessaryVarAnnotation
-         * @psalm-var list<string>
+         * @var array<string>
          */
         $pids = $this->pidManager->read();
 

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole\Command;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -69,6 +70,7 @@ EOH;
 
         $output->writeln('<info>Reloading server ...</info>');
 
+        /** @var Application $application */
         $application = $this->getApplication();
 
         $stop   = $application->find(StopCommand::$defaultName);
@@ -98,7 +100,6 @@ EOH;
             '--num-workers' => $input->getOption('num-workers') ?? StartCommand::DEFAULT_NUM_WORKERS,
         ];
 
-        /** @psalm-suppress MixedAssignment */
         $numTaskWorkers = $input->getOption('num-task-workers');
         if (null !== $numTaskWorkers) {
             $inputArguments['--num-task-workers'] = (int) $numTaskWorkers;

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -20,6 +20,9 @@ use const SWOOLE_PROCESS;
 
 class ReloadCommand extends Command
 {
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOH'
 Reload the web server. Sends a SIGUSR1 signal to master process and reload
 all worker processes.
@@ -32,11 +35,8 @@ EOH;
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:swoole:reload';
 
-    private int $serverMode;
-
-    public function __construct(int $serverMode)
+    public function __construct(private int $serverMode)
     {
-        $this->serverMode = $serverMode;
         parent::__construct();
     }
 
@@ -62,8 +62,7 @@ EOH;
     {
         if ($this->serverMode !== SWOOLE_PROCESS) {
             $output->writeln(
-                '<error>Server is not configured to run in SWOOLE_PROCESS mode;'
-                . ' cannot reload</error>'
+                '<error>Server is not configured to run in SWOOLE_PROCESS mode; cannot reload</error>'
             );
             return 1;
         }
@@ -83,10 +82,11 @@ EOH;
         }
 
         $output->write('<info>Waiting for 5 seconds to ensure server is stopped...</info>');
-        for ($i = 0; $i < 5; $i += 1) {
+        for ($i = 0; $i < 5; ++$i) {
             $output->write('<info>.</info>');
             sleep(1);
         }
+
         $output->writeln('<info>[DONE]</info>');
         $output->writeln('<info>Starting server</info>');
 

--- a/src/Command/ReloadCommandFactory.php
+++ b/src/Command/ReloadCommandFactory.php
@@ -16,8 +16,9 @@ class ReloadCommandFactory
 {
     public function __invoke(ContainerInterface $container): ReloadCommand
     {
-        $config = $container->has('config') ? $container->get('config') : [];
-        $mode   = $config['mezzio-swoole']['swoole-http-server']['mode'] ?? SWOOLE_BASE;
+        $config = $container->has('config') ? (array) $container->get('config') : [];
+
+        $mode = $config['mezzio-swoole']['swoole-http-server']['mode'] ?? SWOOLE_BASE;
 
         return new ReloadCommand($mode);
     }

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -115,6 +115,7 @@ EOH;
         }
 
         if ([] !== $serverOptions) {
+            /** @var SwooleHttpServer $server */
             $server = $this->container->get(SwooleHttpServer::class);
             $server->set($serverOptions);
         }

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -24,8 +24,16 @@ class StartCommand extends Command
 {
     use IsRunningTrait;
 
+    public PidManager $pidManager;
+
+    /**
+     * @var int
+     */
     public const DEFAULT_NUM_WORKERS = 4;
 
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOH'
 Start the web server. If --daemonize is provided, starts the server as a
 background process and returns handling to the shell; otherwise, the
@@ -35,6 +43,9 @@ Use --num-workers to control how many worker processes to start. If you
 do not provide the option, 4 workers will be started.
 EOH;
 
+    /**
+     * @var string[]
+     */
     private const PROGRAMMATIC_CONFIG_FILES = [
         'config/pipeline.php',
         'config/routes.php',
@@ -43,11 +54,8 @@ EOH;
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:swoole:start';
 
-    private ContainerInterface $container;
-
-    public function __construct(ContainerInterface $container)
+    public function __construct(private ContainerInterface $container)
     {
-        $this->container = $container;
         parent::__construct();
     }
 
@@ -95,9 +103,11 @@ EOH;
         if ($daemonize) {
             $serverOptions['daemonize'] = $daemonize;
         }
+
         if (null !== $numWorkers) {
             $serverOptions['worker_num'] = (int) $numWorkers;
         }
+
         if (null !== $numTaskWorkers) {
             $serverOptions['task_worker_num'] = (int) $numTaskWorkers;
         }

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -85,7 +85,9 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var PidManager $this->pidManager */
         $this->pidManager = $this->container->get(PidManager::class);
+
         if ($this->isRunning()) {
             $output->writeln('<error>Server is already running!</error>');
             return 1;

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -17,6 +17,9 @@ class StatusCommand extends Command
 {
     use IsRunningTrait;
 
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOH'
 Find out if the server is running.
 
@@ -27,11 +30,8 @@ EOH;
     /** @var null|string Cannot be defined explicitly due to parent class */
     public static $defaultName = 'mezzio:swoole:status';
 
-    private PidManager $pidManager;
-
-    public function __construct(PidManager $pidManager)
+    public function __construct(private PidManager $pidManager)
     {
-        $this->pidManager = $pidManager;
         parent::__construct();
     }
 

--- a/src/Command/StatusCommandFactory.php
+++ b/src/Command/StatusCommandFactory.php
@@ -15,6 +15,8 @@ class StatusCommandFactory
 {
     public function __invoke(ContainerInterface $container): StatusCommand
     {
-        return new StatusCommand($container->get(PidManager::class));
+        /** @var PidManager $pidManager */
+        $pidManager = $container->get(PidManager::class);
+        return new StatusCommand($pidManager);
     }
 }

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -22,6 +22,9 @@ class StopCommand extends Command
 {
     use IsRunningTrait;
 
+    /**
+     * @var string
+     */
     public const HELP = <<<'EOH'
 Stop the web server. Kills all worker processes and stops the web server.
 
@@ -48,12 +51,9 @@ EOH;
      */
     public int $waitThreshold = 60;
 
-    private PidManager $pidManager;
-
-    public function __construct(PidManager $pidManager)
+    public function __construct(private PidManager $pidManager)
     {
         $this->killProcess = Closure::fromCallable([SwooleProcess::class, 'kill']);
-        $this->pidManager  = $pidManager;
         parent::__construct();
     }
 
@@ -91,10 +91,12 @@ EOH;
             if (! ($this->killProcess)((int) $masterPid, 0)) {
                 continue;
             }
+
             if (time() - $startTime >= $this->waitThreshold) {
                 $result = false;
                 break;
             }
+
             usleep(10000);
         }
 

--- a/src/Command/StopCommandFactory.php
+++ b/src/Command/StopCommandFactory.php
@@ -15,6 +15,8 @@ class StopCommandFactory
 {
     public function __invoke(ContainerInterface $container): StopCommand
     {
-        return new StopCommand($container->get(PidManager::class));
+        /** @var PidManager $pidManager */
+        $pidManager = $container->get(PidManager::class);
+        return new StopCommand($pidManager);
     }
 }

--- a/src/Event/AbstractServerAwareEvent.php
+++ b/src/Event/AbstractServerAwareEvent.php
@@ -12,11 +12,8 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 abstract class AbstractServerAwareEvent
 {
-    protected SwooleHttpServer $server;
-
-    public function __construct(SwooleHttpServer $server)
+    public function __construct(protected SwooleHttpServer $server)
     {
-        $this->server = $server;
     }
 
     public function getServer(): SwooleHttpServer

--- a/src/Event/AbstractSwooleWorkerEvent.php
+++ b/src/Event/AbstractSwooleWorkerEvent.php
@@ -12,12 +12,9 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 abstract class AbstractSwooleWorkerEvent extends AbstractServerAwareEvent
 {
-    protected int $workerId;
-
-    public function __construct(SwooleHttpServer $server, int $workerId)
+    public function __construct(SwooleHttpServer $server, protected int $workerId)
     {
-        $this->server   = $server;
-        $this->workerId = $workerId;
+        $this->server = $server;
     }
 
     public function getWorkerId(): int

--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -34,10 +34,10 @@ class EventDispatcher implements EventDispatcherInterface
         foreach ($this->listenerProvider->getListenersForEvent($event) as $listener) {
             /** @psalm-suppress MixedFunctionCall */
             $listener($event);
-            /** @psalm-suppress MixedMethodCall */
             if (! $stoppable) {
                 continue;
             }
+            /** @psalm-suppress MixedMethodCall */
             if (! $event->isPropagationStopped()) {
                 continue;
             }

--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -14,11 +14,8 @@ use Psr\EventDispatcher\StoppableEventInterface;
 
 class EventDispatcher implements EventDispatcherInterface
 {
-    private ListenerProviderInterface $listenerProvider;
-
-    public function __construct(ListenerProviderInterface $listenerProvider)
+    public function __construct(private ListenerProviderInterface $listenerProvider)
     {
-        $this->listenerProvider = $listenerProvider;
     }
 
     /**
@@ -37,11 +34,14 @@ class EventDispatcher implements EventDispatcherInterface
         foreach ($this->listenerProvider->getListenersForEvent($event) as $listener) {
             /** @psalm-suppress MixedFunctionCall */
             $listener($event);
-
             /** @psalm-suppress MixedMethodCall */
-            if ($stoppable && $event->isPropagationStopped()) {
-                break;
+            if (! $stoppable) {
+                continue;
             }
+            if (! $event->isPropagationStopped()) {
+                continue;
+            }
+            break;
         }
 
         return $event;

--- a/src/Event/HotCodeReloaderWorkerStartListener.php
+++ b/src/Event/HotCodeReloaderWorkerStartListener.php
@@ -13,20 +13,14 @@ use Psr\Log\LoggerInterface;
 
 class HotCodeReloaderWorkerStartListener
 {
-    /**
-     * A file watcher to monitor changes in files.
-     */
-    private FileWatcherInterface $fileWatcher;
-
-    private LoggerInterface $logger;
-
-    private int $interval;
-
-    public function __construct(FileWatcherInterface $fileWatcher, LoggerInterface $logger, int $interval)
-    {
-        $this->fileWatcher = $fileWatcher;
-        $this->logger      = $logger;
-        $this->interval    = $interval;
+    public function __construct(
+        /**
+         * A file watcher to monitor changes in files.
+         */
+        private FileWatcherInterface $fileWatcher,
+        private LoggerInterface $logger,
+        private int $interval
+    ) {
     }
 
     public function __invoke(WorkerStartEvent $event): void
@@ -41,13 +35,14 @@ class HotCodeReloaderWorkerStartListener
 
         $server->tick($this->interval, static function () use ($server, $fileWatcher, $logger): void {
             $changedFilePaths = $fileWatcher->readChangedFilePaths();
-            if (! $changedFilePaths) {
+            if ($changedFilePaths === []) {
                 return;
             }
 
             foreach ($changedFilePaths as $path) {
                 $logger->notice('Reloading due to file change: {path}', ['path' => $path]);
             }
+
             $server->reload();
         });
     }

--- a/src/Event/HotCodeReloaderWorkerStartListener.php
+++ b/src/Event/HotCodeReloaderWorkerStartListener.php
@@ -10,6 +10,7 @@ namespace Mezzio\Swoole\Event;
 
 use Mezzio\Swoole\HotCodeReload\FileWatcherInterface;
 use Psr\Log\LoggerInterface;
+use Swoole\Server;
 
 class HotCodeReloaderWorkerStartListener
 {
@@ -29,6 +30,7 @@ class HotCodeReloaderWorkerStartListener
             return;
         }
 
+        /** @var Server $server */
         $server      = $event->getServer();
         $fileWatcher = $this->fileWatcher;
         $logger      = $this->logger;

--- a/src/Event/ProcessNameTrait.php
+++ b/src/Event/ProcessNameTrait.php
@@ -29,6 +29,7 @@ trait ProcessNameTrait
         if (PHP_OS === 'Darwin') {
             return;
         }
+
         (self::$setProcessName)($name);
     }
 }

--- a/src/Event/RequestEvent.php
+++ b/src/Event/RequestEvent.php
@@ -14,18 +14,10 @@ use Swoole\Http\Response as SwooleHttpResponse;
 
 class RequestEvent implements StoppableEventInterface
 {
-    private SwooleHttpRequest $request;
-
-    private SwooleHttpResponse $response;
-
     private bool $responseSent = false;
 
-    public function __construct(
-        SwooleHttpRequest $request,
-        SwooleHttpResponse $response
-    ) {
-        $this->request  = $request;
-        $this->response = $response;
+    public function __construct(private SwooleHttpRequest $request, private SwooleHttpResponse $response)
+    {
     }
 
     public function isPropagationStopped(): bool

--- a/src/Event/ServerShutdownEvent.php
+++ b/src/Event/ServerShutdownEvent.php
@@ -12,11 +12,8 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 class ServerShutdownEvent
 {
-    private SwooleHttpServer $server;
-
-    public function __construct(SwooleHttpServer $server)
+    public function __construct(private SwooleHttpServer $server)
     {
-        $this->server = $server;
     }
 
     public function getServer(): SwooleHttpServer

--- a/src/Event/ServerShutdownListener.php
+++ b/src/Event/ServerShutdownListener.php
@@ -13,16 +13,8 @@ use Psr\Log\LoggerInterface;
 
 class ServerShutdownListener
 {
-    private LoggerInterface $logger;
-
-    private PidManager $pidManager;
-
-    public function __construct(
-        PidManager $pidManager,
-        LoggerInterface $logger
-    ) {
-        $this->pidManager = $pidManager;
-        $this->logger     = $logger;
+    public function __construct(private PidManager $pidManager, private LoggerInterface $logger)
+    {
     }
 
     public function __invoke(ServerShutdownEvent $event): void

--- a/src/Event/ServerStartEvent.php
+++ b/src/Event/ServerStartEvent.php
@@ -12,11 +12,8 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 class ServerStartEvent
 {
-    private SwooleHttpServer $server;
-
-    public function __construct(SwooleHttpServer $server)
+    public function __construct(private SwooleHttpServer $server)
     {
-        $this->server = $server;
     }
 
     public function getServer(): SwooleHttpServer

--- a/src/Event/ServerStartListener.php
+++ b/src/Event/ServerStartListener.php
@@ -25,24 +25,12 @@ class ServerStartListener
 {
     use ProcessNameTrait;
 
-    private string $cwd;
-
-    private LoggerInterface $logger;
-
-    private PidManager $pidManager;
-
-    private string $processName;
-
     public function __construct(
-        PidManager $pidManager,
-        LoggerInterface $logger,
-        string $cwd,
-        string $processName = SwooleRequestHandlerRunner::DEFAULT_PROCESS_NAME
+        private PidManager $pidManager,
+        private LoggerInterface $logger,
+        private string $cwd,
+        private string $processName = SwooleRequestHandlerRunner::DEFAULT_PROCESS_NAME
     ) {
-        $this->pidManager  = $pidManager;
-        $this->logger      = $logger;
-        $this->cwd         = $cwd;
-        $this->processName = $processName;
     }
 
     public function __invoke(ServerStartEvent $event): void

--- a/src/Event/StaticResourceRequestListener.php
+++ b/src/Event/StaticResourceRequestListener.php
@@ -9,20 +9,15 @@ declare(strict_types=1);
 namespace Mezzio\Swoole\Event;
 
 use Mezzio\Swoole\Log\AccessLogInterface;
+use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
 use Mezzio\Swoole\StaticResourceHandlerInterface;
 
 class StaticResourceRequestListener
 {
-    private AccessLogInterface $logger;
-
-    private StaticResourceHandlerInterface $staticResourceHandler;
-
     public function __construct(
-        StaticResourceHandlerInterface $staticResourceHandler,
-        AccessLogInterface $logger
+        private StaticResourceHandlerInterface $staticResourceHandler,
+        private AccessLogInterface $logger
     ) {
-        $this->staticResourceHandler = $staticResourceHandler;
-        $this->logger                = $logger;
     }
 
     public function __invoke(RequestEvent $event): void
@@ -32,7 +27,7 @@ class StaticResourceRequestListener
 
         $staticResourceResponse = $this->staticResourceHandler->processStaticResource($request, $response);
 
-        if (! $staticResourceResponse) {
+        if (! $staticResourceResponse instanceof StaticResourceResponse) {
             return;
         }
 

--- a/src/Event/SwooleListenerProviderFactory.php
+++ b/src/Event/SwooleListenerProviderFactory.php
@@ -45,10 +45,7 @@ class SwooleListenerProviderFactory
         return $provider;
     }
 
-    /**
-     * @param string|callable $listener
-     */
-    private function prepareListener(ContainerInterface $container, $listener, string $event): callable
+    private function prepareListener(ContainerInterface $container, string|callable $listener, string $event): callable
     {
         if (is_callable($listener)) {
             return $listener;

--- a/src/Event/TaskEvent.php
+++ b/src/Event/TaskEvent.php
@@ -15,16 +15,15 @@ class TaskEvent extends AbstractTaskEvent implements StoppableEventInterface
 {
     /** @var mixed */
     private $returnValue;
+
     private bool $taskProcessed = false;
-    private int $workerId;
 
     /** @param mixed $data */
-    public function __construct(SwooleHttpServer $server, int $taskId, int $workerId, $data)
+    public function __construct(SwooleHttpServer $server, int $taskId, private int $workerId, $data)
     {
-        $this->server   = $server;
-        $this->taskId   = $taskId;
-        $this->workerId = $workerId;
-        $this->data     = $data;
+        $this->server = $server;
+        $this->taskId = $taskId;
+        $this->data   = $data;
     }
 
     public function isPropagationStopped(): bool
@@ -37,8 +36,7 @@ class TaskEvent extends AbstractTaskEvent implements StoppableEventInterface
         $this->taskProcessed = true;
     }
 
-    /** @param mixed $returnValue */
-    public function setReturnValue($returnValue): void
+    public function setReturnValue(mixed $returnValue): void
     {
         $this->returnValue = $returnValue;
     }

--- a/src/Event/WorkerErrorEvent.php
+++ b/src/Event/WorkerErrorEvent.php
@@ -12,15 +12,10 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 class WorkerErrorEvent extends AbstractSwooleWorkerEvent
 {
-    private int $exitCode;
-    private int $signal;
-
-    public function __construct(SwooleHttpServer $server, int $workerId, int $exitCode, int $signal)
+    public function __construct(SwooleHttpServer $server, int $workerId, private int $exitCode, private int $signal)
     {
         $this->server   = $server;
         $this->workerId = $workerId;
-        $this->exitCode = $exitCode;
-        $this->signal   = $signal;
     }
 
     public function getExitCode(): int

--- a/src/Event/WorkerStartListener.php
+++ b/src/Event/WorkerStartListener.php
@@ -23,20 +23,11 @@ class WorkerStartListener
 {
     use ProcessNameTrait;
 
-    private string $cwd;
-
-    private LoggerInterface $logger;
-
-    private string $processName;
-
     public function __construct(
-        LoggerInterface $logger,
-        string $cwd,
-        string $processName = SwooleRequestHandlerRunner::DEFAULT_PROCESS_NAME
+        private LoggerInterface $logger,
+        private string $cwd,
+        private string $processName = SwooleRequestHandlerRunner::DEFAULT_PROCESS_NAME
     ) {
-        $this->logger      = $logger;
-        $this->cwd         = $cwd;
-        $this->processName = $processName;
     }
 
     public function __invoke(WorkerStartEvent $event): void

--- a/src/Exception/InvalidListenerException.php
+++ b/src/Exception/InvalidListenerException.php
@@ -8,22 +8,17 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole\Exception;
 
-use function get_class;
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 class InvalidListenerException extends InvalidArgumentException
 {
-    /**
-     * @param mixed $listener
-     */
-    public static function forListenerOfEvent($listener, string $event): self
+    public static function forListenerOfEvent(mixed $listener, string $event): self
     {
         return new self(sprintf(
             'Unexpected listener for event "%s"; expected callable or string service name, received %s',
             $event,
-            is_object($listener) ? get_class($listener) : gettype($listener)
+            get_debug_type($listener)
         ));
     }
 

--- a/src/Exception/InvalidStaticResourceMiddlewareException.php
+++ b/src/Exception/InvalidStaticResourceMiddlewareException.php
@@ -8,22 +8,16 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole\Exception;
 
-use function get_class;
-use function gettype;
-use function is_object;
+use function get_debug_type;
 use function sprintf;
 
 class InvalidStaticResourceMiddlewareException extends InvalidArgumentException
 {
-    /**
-     * @param mixed      $middleware
-     * @param int|string $position
-     */
-    public static function forMiddlewareAtPosition($middleware, $position): self
+    public static function forMiddlewareAtPosition(mixed $middleware, int|string $position): self
     {
         return new self(sprintf(
             'Static resource middleware must be callable; received middleware of type "%s" in position %s',
-            is_object($middleware) ? get_class($middleware) : gettype($middleware),
+            get_debug_type($middleware),
             $position
         ));
     }

--- a/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
+++ b/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
@@ -15,7 +15,6 @@ use Webmozart\Assert\Assert;
 
 use function array_values;
 use function extension_loaded;
-use function function_exists;
 use function in_array;
 use function inotify_add_watch;
 use function inotify_init;
@@ -39,9 +38,6 @@ class InotifyFileWatcher implements FileWatcherInterface
     public function __construct()
     {
         if (! extension_loaded('inotify')) {
-            throw new ExtensionNotLoadedException('PHP extension "inotify" is required for this file watcher');
-        }
-        if (! function_exists('inotify_init')) {
             throw new ExtensionNotLoadedException('PHP extension "inotify" is required for this file watcher');
         }
 
@@ -79,6 +75,7 @@ class InotifyFileWatcher implements FileWatcherInterface
         if (is_array($events)) {
             foreach ($events as $event) {
                 Assert::isArray($event);
+                /** @var ?string $wd */
                 $wd = $event['wd'] ?? null;
                 if (null === $wd) {
                     throw new RuntimeException('Missing watch descriptor from inotify event');

--- a/src/HttpServerFactory.php
+++ b/src/HttpServerFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Mezzio\Swoole;
 
 use ArrayAccess;
+use Mezzio\Swoole\Exception\InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Swoole\Http\Server as SwooleHttpServer;
 use Swoole\Runtime as SwooleRuntime;
@@ -32,11 +33,20 @@ use const SWOOLE_UNIX_STREAM;
 
 class HttpServerFactory
 {
+    /**
+     * @var string
+     */
     public const DEFAULT_HOST = '127.0.0.1';
+
+    /**
+     * @var int
+     */
     public const DEFAULT_PORT = 8080;
 
     /**
      * Swoole server supported modes
+     *
+     * @var int[]
      */
     private const MODES = [
         SWOOLE_BASE,
@@ -45,6 +55,8 @@ class HttpServerFactory
 
     /**
      * Swoole server supported protocols
+     *
+     * @var int[]
      */
     private const PROTOCOLS = [
         SWOOLE_SOCK_TCP,
@@ -59,9 +71,9 @@ class HttpServerFactory
      * @see https://www.swoole.co.uk/docs/modules/swoole-server-methods#swoole_server-__construct
      * @see https://www.swoole.co.uk/docs/modules/swoole-server/predefined-constants for $mode and $protocol constant
      *
-     * @throws Exception\InvalidArgumentException For invalid $port values.
-     * @throws Exception\InvalidArgumentException For invalid $mode values.
-     * @throws Exception\InvalidArgumentException For invalid $protocol values.
+     * @throws InvalidArgumentException For invalid $port values.
+     * @throws InvalidArgumentException For invalid $mode values.
+     * @throws InvalidArgumentException For invalid $protocol values.
      */
     public function __invoke(ContainerInterface $container): SwooleHttpServer
     {
@@ -80,11 +92,11 @@ class HttpServerFactory
         $protocol = $serverConfig['protocol'] ?? SWOOLE_SOCK_TCP;
 
         if ($port < 1 || $port > 65535) {
-            throw new Exception\InvalidArgumentException('Invalid port');
+            throw new InvalidArgumentException('Invalid port');
         }
 
         if (! in_array($mode, static::MODES, true)) {
-            throw new Exception\InvalidArgumentException('Invalid server mode');
+            throw new InvalidArgumentException('Invalid server mode');
         }
 
         $validProtocols = static::PROTOCOLS;
@@ -94,7 +106,7 @@ class HttpServerFactory
         }
 
         if (! in_array($protocol, $validProtocols, true)) {
-            throw new Exception\InvalidArgumentException('Invalid server protocol');
+            throw new InvalidArgumentException('Invalid server protocol');
         }
 
         $enableCoroutine = $swooleConfig['enable_coroutine'] ?? false;

--- a/src/Log/AccessLogFormatter.php
+++ b/src/Log/AccessLogFormatter.php
@@ -14,15 +14,35 @@ class AccessLogFormatter implements AccessLogFormatterInterface
 {
     /**
      * @link http://httpd.apache.org/docs/2.4/mod/mod_log_config.html#examples
+     *
+     * @var string
      */
-    public const FORMAT_COMMON       = '%h %l %u %t "%r" %>s %b';
+    public const FORMAT_COMMON = '%h %l %u %t "%r" %>s %b';
+
+    /**
+     * @var string
+     */
     public const FORMAT_COMMON_VHOST = '%v %h %l %u %t "%r" %>s %b';
-    public const FORMAT_COMBINED     = '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"';
-    public const FORMAT_REFERER      = '%{Referer}i -> %U';
-    public const FORMAT_AGENT        = '%{User-Agent}i';
+
+    /**
+     * @var string
+     */
+    public const FORMAT_COMBINED = '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"';
+
+    /**
+     * @var string
+     */
+    public const FORMAT_REFERER = '%{Referer}i -> %U';
+
+    /**
+     * @var string
+     */
+    public const FORMAT_AGENT = '%{User-Agent}i';
 
     /**
      * @link https://httpd.apache.org/docs/2.4/logs.html#virtualhost
+     *
+     * @var string
      */
     public const FORMAT_VHOST = '%v %l %u %t "%r" %>s %b';
 
@@ -30,20 +50,27 @@ class AccessLogFormatter implements AccessLogFormatterInterface
      * @link https://anonscm.debian.org/cgit/pkg-apache/apache2.git/tree/debian/config-dir/apache2.conf.in#n212
      *
      * phpcs:disable
+     * @var string
      */
     public const FORMAT_COMMON_DEBIAN = '%h %l %u %t “%r” %>s %O';
-    public const FORMAT_COMBINED_DEBIAN = '%h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i”';
-    public const FORMAT_VHOST_COMBINED_DEBIAN = '%v:%p %h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i"';
-    // phpcs:enable
 
     /**
-     * Message format to use when generating a log message.
+     * @var string
      */
-    private string $format;
+    public const FORMAT_COMBINED_DEBIAN = '%h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i”';
 
-    public function __construct(string $format = self::FORMAT_COMMON)
-    {
-        $this->format = $format;
+    /**
+     * @var string
+     */
+    public const FORMAT_VHOST_COMBINED_DEBIAN = '%v:%p %h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i"';
+
+    public function __construct(
+        // phpcs:enable
+        /**
+         * Message format to use when generating a log message.
+         */
+        private string $format = self::FORMAT_COMMON
+    ) {
     }
 
     /**
@@ -52,8 +79,7 @@ class AccessLogFormatter implements AccessLogFormatterInterface
     public function format(AccessLogDataMap $map): string
     {
         $message = $this->replaceConstantDirectives($this->format, $map);
-        $message = $this->replaceVariableDirectives($message, $map);
-        return $message;
+        return $this->replaceVariableDirectives($message, $map);
     }
 
     private function replaceConstantDirectives(
@@ -61,65 +87,32 @@ class AccessLogFormatter implements AccessLogFormatterInterface
         AccessLogDataMap $map
     ): string {
         return preg_replace_callback(
-            '/%(?:[<>])?([%aABbDfhHklLmpPqrRstTuUvVXIOS])/',
-            static function (array $matches) use ($map) {
-                switch ($matches[1]) {
-                    case '%':
-                        return '%';
-                    case 'a':
-                        return $map->getClientIp();
-                    case 'A':
-                        return $map->getLocalIp();
-                    case 'B':
-                        return $map->getBodySize('0');
-                    case 'b':
-                        return $map->getBodySize('-');
-                    case 'D':
-                        return $map->getRequestDuration('ms');
-                    case 'f':
-                        return $map->getFilename();
-                    case 'h':
-                        return $map->getRemoteHostname();
-                    case 'H':
-                        return $map->getProtocol();
-                    case 'm':
-                        return $map->getMethod();
-                    case 'p':
-                        return $map->getPort('canonical');
-                    case 'q':
-                        return $map->getQuery();
-                    case 'r':
-                        return $map->getRequestLine();
-                    case 's':
-                        return $map->getStatus();
-                    case 't':
-                        return $map->getRequestTime('begin:%d/%b/%Y:%H:%M:%S %z');
-                    case 'T':
-                        return $map->getRequestDuration('s');
-                    case 'u':
-                        return $map->getRemoteUser();
-                    case 'U':
-                        return $map->getPath();
-                    case 'v':
-                        return $map->getHost();
-                    case 'V':
-                        return $map->getServerName();
-                    case 'I':
-                        return $map->getRequestMessageSize('-');
-                    case 'O':
-                        return $map->getResponseMessageSize('-');
-                    case 'S':
-                        return $map->getTransferredSize();
-                    //NOT IMPLEMENTED
-                    case 'k':
-                    case 'l':
-                    case 'L':
-                    case 'P':
-                    case 'R':
-                    case 'X':
-                    default:
-                        return '-';
-                }
+            '#%(?:[<>])?([%aABbDfhHklLmpPqrRstTuUvVXIOS])#',
+            static fn(array $matches) => match ($matches[1]) {
+                '%' => '%',
+                'a' => $map->getClientIp(),
+                'A' => $map->getLocalIp(),
+                'B' => $map->getBodySize('0'),
+                'b' => $map->getBodySize('-'),
+                'D' => $map->getRequestDuration('ms'),
+                'f' => $map->getFilename(),
+                'h' => $map->getRemoteHostname(),
+                'H' => $map->getProtocol(),
+                'm' => $map->getMethod(),
+                'p' => $map->getPort('canonical'),
+                'q' => $map->getQuery(),
+                'r' => $map->getRequestLine(),
+                's' => $map->getStatus(),
+                't' => $map->getRequestTime('begin:%d/%b/%Y:%H:%M:%S %z'),
+                'T' => $map->getRequestDuration('s'),
+                'u' => $map->getRemoteUser(),
+                'U' => $map->getPath(),
+                'v' => $map->getHost(),
+                'V' => $map->getServerName(),
+                'I' => $map->getRequestMessageSize('-'),
+                'O' => $map->getResponseMessageSize('-'),
+                'S' => $map->getTransferredSize(),
+                default => '-',
             },
             $format
         );
@@ -130,31 +123,17 @@ class AccessLogFormatter implements AccessLogFormatterInterface
         AccessLogDataMap $map
     ): string {
         return preg_replace_callback(
-            '/%(?:[<>])?{([^}]+)}([aCeinopPtT])/',
-            static function (array $matches) use ($map) {
-                switch ($matches[2]) {
-                    case 'a':
-                        return $map->getClientIp();
-                    case 'C':
-                        return $map->getCookie($matches[1]);
-                    case 'e':
-                        return $map->getEnv($matches[1]);
-                    case 'i':
-                        return $map->getRequestHeader($matches[1]);
-                    case 'o':
-                        return $map->getResponseHeader($matches[1]);
-                    case 'p':
-                        return $map->getPort($matches[1]);
-                    case 't':
-                        return $map->getRequestTime($matches[1]);
-                    case 'T':
-                        return $map->getRequestDuration($matches[1]);
-                    //NOT IMPLEMENTED
-                    case 'n':
-                    case 'P':
-                    default:
-                        return '-';
-                }
+            '#%(?:[<>])?{([^}]+)}([aCeinopPtT])#',
+            static fn(array $matches) => match ($matches[2]) {
+                'a' => $map->getClientIp(),
+                'C' => $map->getCookie($matches[1]),
+                'e' => $map->getEnv($matches[1]),
+                'i' => $map->getRequestHeader($matches[1]),
+                'o' => $map->getResponseHeader($matches[1]),
+                'p' => $map->getPort($matches[1]),
+                't' => $map->getRequestTime($matches[1]),
+                'T' => $map->getRequestDuration($matches[1]),
+                default => '-',
             },
             $format
         );

--- a/src/Log/Psr3AccessLogDecorator.php
+++ b/src/Log/Psr3AccessLogDecorator.php
@@ -15,24 +15,15 @@ use Swoole\Http\Request;
 
 class Psr3AccessLogDecorator implements AccessLogInterface
 {
-    private AccessLogFormatterInterface $formatter;
-
-    private LoggerInterface $logger;
-
-    /**
-     * Whether or not to look up remote host names when preparing the access
-     * log message
-     */
-    private bool $useHostnameLookups;
-
     public function __construct(
-        LoggerInterface $logger,
-        AccessLogFormatterInterface $formatter,
-        bool $useHostnameLookups = false
+        private LoggerInterface $logger,
+        private AccessLogFormatterInterface $formatter,
+        /**
+         * Whether or not to look up remote host names when preparing the access
+         * log message
+         */
+        private bool $useHostnameLookups = false
     ) {
-        $this->logger             = $logger;
-        $this->formatter          = $formatter;
-        $this->useHostnameLookups = $useHostnameLookups;
     }
 
     public function logAccessForStaticResource(Request $request, StaticResourceResponse $response): void

--- a/src/Log/StdoutLogger.php
+++ b/src/Log/StdoutLogger.php
@@ -104,6 +104,7 @@ class StdoutLogger implements LoggerInterface
             $search  = sprintf('{%s}', $key);
             $message = str_replace($search, $value, $message);
         }
+
         printf('%s%s', $message, PHP_EOL);
     }
 }

--- a/src/Log/StrftimeToICUFormatMap.php
+++ b/src/Log/StrftimeToICUFormatMap.php
@@ -27,7 +27,7 @@ final class StrftimeToICUFormatMap
     public static function mapStrftimeToICU(string $format, DateTimeInterface $requestTime): string
     {
         return preg_replace_callback(
-            '/(?P<token>%[aAbBcCdDeFgGhHIjklmMpPrRsSTuUVwWxXyYzZ])/',
+            '#(?P<token>%[aAbBcCdDeFgGhHIjklmMpPrRsSTuUVwWxXyYzZ])#',
             self::generateMapCallback($requestTime),
             $format
         );
@@ -41,83 +41,47 @@ final class StrftimeToICUFormatMap
         /** @psalm-param array<array-key, string> */
         return static function (array $matches) use ($requestTime): string {
             Assert::keyExists($matches, 'token');
-            switch (true) {
-                case $matches['token'] === '%a':
-                    return 'eee';
-                case $matches['token'] === '%A':
-                    return 'eeee';
-                case $matches['token'] === '%b':
-                    return 'MMM';
-                case $matches['token'] === '%B':
-                    return 'MMMM';
-                case $matches['token'] === '%C':
-                    return 'yy';
-                case $matches['token'] === '%d':
-                    return 'dd';
-                case $matches['token'] === '%D':
-                    return 'MM/dd/yy';
-                case $matches['token'] === '%e':
-                    return ' d';
-                case $matches['token'] === '%F':
-                    return 'y-MM-dd';
-                case $matches['token'] === '%g':
-                    return 'yy';
-                case $matches['token'] === '%G':
-                    return 'y';
-                case $matches['token'] === '%h':
-                    return 'MMM';
-                case $matches['token'] === '%H':
-                    return 'HH';
-                case $matches['token'] === '%I':
-                    return 'KK';
-                case $matches['token'] === '%j':
-                    return 'D';
-                case $matches['token'] === '%k':
-                    return ' H';
-                case $matches['token'] === '%l':
-                    return ' h';
-                case $matches['token'] === '%m':
-                    return 'MM';
-                case $matches['token'] === '%M':
-                    return 'mm';
-                case $matches['token'] === '%p':
-                    return 'a';
-                case $matches['token'] === '%P':
-                    return 'a';
-                case $matches['token'] === '%r':
-                    return ' h:mm:ss a';
-                case $matches['token'] === '%R':
-                    return 'HH:mm';
-                case $matches['token'] === '%S':
-                    return 'ss';
-                case $matches['token'] === '%s':
-                    return (string) $requestTime->getTimestamp();
-                case $matches['token'] === '%T':
-                    return 'HH:mm:ss';
-                case $matches['token'] === '%u':
-                    return 'e';
-                case $matches['token'] === '%U':
-                    return 'ww';
-                case $matches['token'] === '%w':
-                    return 'c';
-                case $matches['token'] === '%W':
-                    return 'ww';
-                case $matches['token'] === '%V':
-                    return 'ww';
-                case $matches['token'] === '%y':
-                    return 'yy';
-                case $matches['token'] === '%Y':
-                    return 'y';
-                case $matches['token'] === '%z':
-                    return 'xx';
-                case $matches['token'] === '%Z':
-                    return 'z';
-                default:
-                    throw new RuntimeException(sprintf(
-                        'The request time format token "%s" is unsupported; please use ICU Date/Time format codes',
-                        $matches['token']
-                    ));
-            }
+            return match (true) {
+                $matches['token'] === '%a' => 'eee',
+                $matches['token'] === '%A' => 'eeee',
+                $matches['token'] === '%b' => 'MMM',
+                $matches['token'] === '%B' => 'MMMM',
+                $matches['token'] === '%C' => 'yy',
+                $matches['token'] === '%d' => 'dd',
+                $matches['token'] === '%D' => 'MM/dd/yy',
+                $matches['token'] === '%e' => ' d',
+                $matches['token'] === '%F' => 'y-MM-dd',
+                $matches['token'] === '%g' => 'yy',
+                $matches['token'] === '%G' => 'y',
+                $matches['token'] === '%h' => 'MMM',
+                $matches['token'] === '%H' => 'HH',
+                $matches['token'] === '%I' => 'KK',
+                $matches['token'] === '%j' => 'D',
+                $matches['token'] === '%k' => ' H',
+                $matches['token'] === '%l' => ' h',
+                $matches['token'] === '%m' => 'MM',
+                $matches['token'] === '%M' => 'mm',
+                $matches['token'] === '%p' => 'a',
+                $matches['token'] === '%P' => 'a',
+                $matches['token'] === '%r' => ' h:mm:ss a',
+                $matches['token'] === '%R' => 'HH:mm',
+                $matches['token'] === '%S' => 'ss',
+                $matches['token'] === '%s' => (string) $requestTime->getTimestamp(),
+                $matches['token'] === '%T' => 'HH:mm:ss',
+                $matches['token'] === '%u' => 'e',
+                $matches['token'] === '%U' => 'ww',
+                $matches['token'] === '%w' => 'c',
+                $matches['token'] === '%W' => 'ww',
+                $matches['token'] === '%V' => 'ww',
+                $matches['token'] === '%y' => 'yy',
+                $matches['token'] === '%Y' => 'y',
+                $matches['token'] === '%z' => 'xx',
+                $matches['token'] === '%Z' => 'z',
+                default => throw new RuntimeException(sprintf(
+                    'The request time format token "%s" is unsupported; please use ICU Date/Time format codes',
+                    $matches['token']
+                )),
+            };
         };
     }
 }

--- a/src/Log/SwooleLoggerFactory.php
+++ b/src/Log/SwooleLoggerFactory.php
@@ -16,6 +16,9 @@ use function is_string;
 
 class SwooleLoggerFactory
 {
+    /**
+     * @var string
+     */
     public const SWOOLE_LOGGER = 'Mezzio\Swoole\Log\SwooleLogger';
 
     public function __invoke(ContainerInterface $container): LoggerInterface

--- a/src/PidManager.php
+++ b/src/PidManager.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole;
 
+use Mezzio\Swoole\Exception\RuntimeException;
+
 use function dirname;
 use function explode;
 use function file_get_contents;
@@ -19,23 +21,21 @@ use function unlink;
 
 class PidManager
 {
-    private string $pidFile = '';
-
-    public function __construct(string $pidFile)
+    public function __construct(private string $pidFile)
     {
-        $this->pidFile = $pidFile;
     }
 
     /**
      * Write master pid and manager pid to pid file
      *
-     * @throws Exception\RuntimeException When $pidFile is not writable.
+     * @throws RuntimeException When $pidFile is not writable.
      */
     public function write(int $masterPid, int $managerPid): void
     {
         if (! is_writable($this->pidFile) && ! is_writable(dirname($this->pidFile))) {
-            throw new Exception\RuntimeException(sprintf('Pid file "%s" is not writable', $this->pidFile));
+            throw new RuntimeException(sprintf('Pid file "%s" is not writable', $this->pidFile));
         }
+
         file_put_contents($this->pidFile, $masterPid . ',' . $managerPid);
     }
 
@@ -52,6 +52,7 @@ class PidManager
             $content = file_get_contents($this->pidFile);
             $pids    = explode(',', $content);
         }
+
         return $pids;
     }
 
@@ -63,6 +64,7 @@ class PidManager
         if (is_writable($this->pidFile)) {
             return unlink($this->pidFile);
         }
+
         return false;
     }
 }

--- a/src/ServerRequestSwooleFactory.php
+++ b/src/ServerRequestSwooleFactory.php
@@ -31,12 +31,13 @@ class ServerRequestSwooleFactory
 {
     public function __invoke(ContainerInterface $container): callable
     {
+        /** @var FilterServerRequestInterface $requestFilter */
         $requestFilter = $container->has(FilterServerRequestInterface::class)
             ? $container->get(FilterServerRequestInterface::class)
             : FilterUsingXForwardedHeaders::trustReservedSubnets();
 
         $stripXForwardedHeaders = static function (array $headers): array {
-            /** @psalm-var list<string> */
+            /** @var array<array-key,string> $disallowedHeaders */
             static $disallowedHeaders = [
                 'X-FORWARDED-FOR',
                 'X-FORWARDED-HOST',
@@ -54,8 +55,12 @@ class ServerRequestSwooleFactory
             return $headers;
         };
 
-        // phpcs:disable Generic.Files.LineLength.TooLong
-        return static function (SwooleHttpRequest $request) use ($requestFilter, $stripXForwardedHeaders): ServerRequestInterface {
+        return static function (
+            SwooleHttpRequest $request
+        ) use (
+            $requestFilter,
+            $stripXForwardedHeaders
+): ServerRequestInterface {
             // Aggregate values from Swoole request object
             $get     = $request->get ?? [];
             $post    = $request->post ?? [];
@@ -84,6 +89,5 @@ class ServerRequestSwooleFactory
                 ? $requestFilter($request)
                 : $request;
         };
-        // phpcs:enable Generic.Files.LineLength.TooLong
     }
 }

--- a/src/StaticMappedResourceHandler.php
+++ b/src/StaticMappedResourceHandler.php
@@ -9,46 +9,46 @@ declare(strict_types=1);
 namespace Mezzio\Swoole;
 
 use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryInterface;
+use Mezzio\Swoole\StaticResourceHandler\MiddlewareQueue;
+use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
+use Mezzio\Swoole\StaticResourceHandler\ValidateMiddlewareTrait;
 use Swoole\Http\Request as SwooleHttpRequest;
 use Swoole\Http\Response as SwooleHttpResponse;
 
 class StaticMappedResourceHandler implements StaticResourceHandlerInterface
 {
-    use StaticResourceHandler\ValidateMiddlewareTrait;
+    use ValidateMiddlewareTrait;
 
     /**
      * Middleware to execute when serving a static resource.
      *
      * @var StaticResourceHandler\MiddlewareInterface[]
      */
-    private array $middleware;
-
-    private FileLocationRepositoryInterface $fileLocationRepo;
+    private array $middleware = [];
 
     /**
      * @throws Exception\InvalidStaticResourceMiddlewareException For any
      *     non-callable middleware encountered.
      */
     public function __construct(
-        FileLocationRepositoryInterface $fileLocationRepo,
+        private FileLocationRepositoryInterface $fileLocationRepo,
         array $middleware = []
     ) {
         $this->validateMiddleware($middleware);
-        $this->middleware       = $middleware;
-        $this->fileLocationRepo = $fileLocationRepo;
+        $this->middleware = $middleware;
     }
 
     public function processStaticResource(
         SwooleHttpRequest $request,
         SwooleHttpResponse $response
-    ): ?StaticResourceHandler\StaticResourceResponse {
+    ): ?StaticResourceResponse {
         /** @psalm-suppress MixedArgument */
         $filename = $this->fileLocationRepo->findFile($request->server['request_uri']);
         if (! $filename) {
             return null;
         }
 
-        $middleware             = new StaticResourceHandler\MiddlewareQueue($this->middleware);
+        $middleware             = new MiddlewareQueue($this->middleware);
         $staticResourceResponse = $middleware($request, $filename);
         if ($staticResourceResponse->isFailure()) {
             return null;

--- a/src/StaticMappedResourceHandler.php
+++ b/src/StaticMappedResourceHandler.php
@@ -42,7 +42,6 @@ class StaticMappedResourceHandler implements StaticResourceHandlerInterface
         SwooleHttpRequest $request,
         SwooleHttpResponse $response
     ): ?StaticResourceResponse {
-        /** @psalm-suppress MixedArgument */
         $filename = $this->fileLocationRepo->findFile($request->server['request_uri']);
         if (! $filename) {
             return null;

--- a/src/StaticMappedResourceHandlerFactory.php
+++ b/src/StaticMappedResourceHandlerFactory.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole;
 
+use Mezzio\Swoole\StaticResourceHandler\FileLocationRepositoryInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -70,7 +71,7 @@ class StaticMappedResourceHandlerFactory extends AbstractStaticResourceHandlerFa
     {
         $config = $container->get('config')['mezzio-swoole']['swoole-http-server']['static-files'] ?? [];
         return new StaticMappedResourceHandler(
-            $container->get(StaticResourceHandler\FileLocationRepositoryInterface::class),
+            $container->get(FileLocationRepositoryInterface::class),
             $this->configureMiddleware($config)
         );
     }

--- a/src/StaticMappedResourceHandlerFactory.php
+++ b/src/StaticMappedResourceHandlerFactory.php
@@ -69,9 +69,13 @@ class StaticMappedResourceHandlerFactory extends AbstractStaticResourceHandlerFa
 {
     public function __invoke(ContainerInterface $container): StaticMappedResourceHandler
     {
+        /** @var array<array-key, mixed> $config */
         $config = $container->get('config')['mezzio-swoole']['swoole-http-server']['static-files'] ?? [];
+
+        /** @var FileLocationRepositoryInterface $fileLocationRepository */
+        $fileLocationRepository = $container->get(FileLocationRepositoryInterface::class);
         return new StaticMappedResourceHandler(
-            $container->get(FileLocationRepositoryInterface::class),
+            $fileLocationRepository,
             $this->configureMiddleware($config)
         );
     }

--- a/src/StaticResourceHandler.php
+++ b/src/StaticResourceHandler.php
@@ -8,6 +8,10 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole;
 
+use Mezzio\Swoole\Exception\InvalidArgumentException;
+use Mezzio\Swoole\StaticResourceHandler\MiddlewareQueue;
+use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
+use Mezzio\Swoole\StaticResourceHandler\ValidateMiddlewareTrait;
 use Swoole\Http\Request as SwooleHttpRequest;
 use Swoole\Http\Response as SwooleHttpResponse;
 
@@ -16,7 +20,7 @@ use function sprintf;
 
 class StaticResourceHandler implements StaticResourceHandlerInterface
 {
-    use StaticResourceHandler\ValidateMiddlewareTrait;
+    use ValidateMiddlewareTrait;
 
     private string $docRoot;
 
@@ -25,7 +29,7 @@ class StaticResourceHandler implements StaticResourceHandlerInterface
      *
      * @var StaticResourceHandler\MiddlewareInterface[]
      */
-    private array $middleware;
+    private array $middleware = [];
 
     /**
      * @throws Exception\InvalidStaticResourceMiddlewareException For any
@@ -36,11 +40,12 @@ class StaticResourceHandler implements StaticResourceHandlerInterface
         array $middleware = []
     ) {
         if (! is_dir($docRoot)) {
-            throw new Exception\InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'The document root "%s" does not exist; please check your configuration.',
                 $docRoot
             ));
         }
+
         $this->validateMiddleware($middleware);
 
         $this->docRoot    = $docRoot;
@@ -50,10 +55,10 @@ class StaticResourceHandler implements StaticResourceHandlerInterface
     public function processStaticResource(
         SwooleHttpRequest $request,
         SwooleHttpResponse $response
-    ): ?StaticResourceHandler\StaticResourceResponse {
+    ): ?StaticResourceResponse {
         $filename = $this->docRoot . $request->server['request_uri'];
 
-        $middleware             = new StaticResourceHandler\MiddlewareQueue($this->middleware);
+        $middleware             = new MiddlewareQueue($this->middleware);
         $staticResourceResponse = $middleware($request, $filename);
         if ($staticResourceResponse->isFailure()) {
             return null;

--- a/src/StaticResourceHandler/CacheControlMiddleware.php
+++ b/src/StaticResourceHandler/CacheControlMiddleware.php
@@ -79,7 +79,7 @@ class CacheControlMiddleware implements MiddlewareInterface
             if (! is_array($directives)) {
                 throw new InvalidArgumentException(sprintf(
                     'The Cache-Control directives associated with the regex "%s" are invalid;'
-                    . ' each must be an array of strings',
+                        . ' each must be an array of strings',
                     $regex
                 ));
             }
@@ -88,7 +88,7 @@ class CacheControlMiddleware implements MiddlewareInterface
                 if (! is_string($directive)) {
                     throw new InvalidArgumentException(sprintf(
                         'One or more Cache-Control directives associated with the regex "%s" are invalid;'
-                        . ' each must be a string',
+                            . ' each must be a string',
                         $regex
                     ));
                 }
@@ -113,7 +113,7 @@ class CacheControlMiddleware implements MiddlewareInterface
 
         throw new InvalidArgumentException(sprintf(
             'The Cache-Control directive "%s" associated with regex "%s" is invalid.'
-            . ' Must be one of [%s] or match /^max-age=\d+$/',
+                . ' Must be one of [%s] or match /^max-age=\d+$/',
             $directive,
             $regex,
             implode(', ', self::CACHECONTROL_DIRECTIVES)

--- a/src/StaticResourceHandler/CacheControlMiddleware.php
+++ b/src/StaticResourceHandler/CacheControlMiddleware.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Mezzio\Swoole\StaticResourceHandler;
 
 use Mezzio\Swoole\Exception;
+use Mezzio\Swoole\Exception\InvalidArgumentException;
 use Swoole\Http\Request;
 
 use function array_walk;
@@ -56,6 +57,7 @@ class CacheControlMiddleware implements MiddlewareInterface
         if ($cacheControl) {
             $response->addHeader('Cache-Control', $cacheControl);
         }
+
         return $response;
     }
 
@@ -68,14 +70,14 @@ class CacheControlMiddleware implements MiddlewareInterface
     {
         foreach ($cacheControlDirectives as $regex => $directives) {
             if (! $this->isValidRegex($regex)) {
-                throw new Exception\InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'The Cache-Control regex "%s" is invalid',
                     $regex
                 ));
             }
 
             if (! is_array($directives)) {
-                throw new Exception\InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'The Cache-Control directives associated with the regex "%s" are invalid;'
                     . ' each must be an array of strings',
                     $regex
@@ -84,12 +86,13 @@ class CacheControlMiddleware implements MiddlewareInterface
 
             array_walk($directives, function ($directive) use ($regex): void {
                 if (! is_string($directive)) {
-                    throw new Exception\InvalidArgumentException(sprintf(
+                    throw new InvalidArgumentException(sprintf(
                         'One or more Cache-Control directives associated with the regex "%s" are invalid;'
                         . ' each must be a string',
                         $regex
                     ));
                 }
+
                 $this->validateCacheControlDirective($regex, $directive);
             });
         }
@@ -103,10 +106,12 @@ class CacheControlMiddleware implements MiddlewareInterface
         if (in_array($directive, self::CACHECONTROL_DIRECTIVES, true)) {
             return;
         }
-        if (preg_match('/^max-age=\d+$/', $directive)) {
+
+        if (preg_match('#^max-age=\d+$#', $directive)) {
             return;
         }
-        throw new Exception\InvalidArgumentException(sprintf(
+
+        throw new InvalidArgumentException(sprintf(
             'The Cache-Control directive "%s" associated with regex "%s" is invalid.'
             . ' Must be one of [%s] or match /^max-age=\d+$/',
             $directive,
@@ -128,6 +133,7 @@ class CacheControlMiddleware implements MiddlewareInterface
                 return implode(', ', $values);
             }
         }
+
         return null;
     }
 }

--- a/src/StaticResourceHandler/ClearStatCacheMiddleware.php
+++ b/src/StaticResourceHandler/ClearStatCacheMiddleware.php
@@ -16,20 +16,18 @@ use function time;
 class ClearStatCacheMiddleware implements MiddlewareInterface
 {
     /**
-     * Interval at which to clear fileystem stat cache. Values below 1 indicate
-     * the stat cache should ALWAYS be cleared. Otherwise, the value is the number
-     * of seconds between clear operations.
-     */
-    private int $interval;
-
-    /**
      * When the filesystem stat cache was last cleared.
      */
     private int $lastCleared = 0;
 
-    public function __construct(int $interval)
-    {
-        $this->interval = $interval;
+    public function __construct(
+        /**
+         * Interval at which to clear fileystem stat cache. Values below 1 indicate
+         * the stat cache should ALWAYS be cleared. Otherwise, the value is the number
+         * of seconds between clear operations.
+         */
+        private int $interval
+    ) {
     }
 
     /**

--- a/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
+++ b/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
@@ -33,6 +33,8 @@ class ContentTypeFilterMiddleware implements MiddlewareInterface
      * Default static file extensions supported
      *
      * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
+     *
+     * @var array<string, string>
      */
     public const TYPE_MAP_DEFAULT = [
         '7z'    => 'application/x-7z-compressed',

--- a/src/StaticResourceHandler/ETagMiddleware.php
+++ b/src/StaticResourceHandler/ETagMiddleware.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole\StaticResourceHandler;
 
-use Mezzio\Swoole\Exception;
+use Mezzio\Swoole\Exception\InvalidArgumentException;
 use Swoole\Http\Request;
 
 use function array_walk;
@@ -27,9 +27,15 @@ class ETagMiddleware implements MiddlewareInterface
 
     /**
      * ETag validation type
+     *
+     * @var string
      */
     public const ETAG_VALIDATION_STRONG = 'strong';
-    public const ETAG_VALIDATION_WEAK   = 'weak';
+
+    /**
+     * @var string
+     */
+    public const ETAG_VALIDATION_WEAK = 'weak';
 
     /** @var string[] */
     private array $allowedETagValidationTypes = [
@@ -41,7 +47,7 @@ class ETagMiddleware implements MiddlewareInterface
      * @var string[] Array of regexp; if a path matches a regexp, an ETag will
      *     be emitted for the static file resource.
      */
-    private array $etagDirectives;
+    private array $etagDirectives = [];
 
     /**
      * ETag validation type, 'weak' means Weak Validation, 'strong' means Strong Validation,
@@ -53,7 +59,7 @@ class ETagMiddleware implements MiddlewareInterface
     {
         $this->validateRegexList($etagDirectives, 'ETag');
         if (! in_array($etagValidationType, $this->allowedETagValidationTypes, true)) {
-            throw new Exception\InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'ETag validation type must be one of [%s]; received "%s"',
                 implode(', ', $this->allowedETagValidationTypes),
                 $etagValidationType
@@ -85,6 +91,7 @@ class ETagMiddleware implements MiddlewareInterface
                 return true;
             }
         }
+
         return false;
     }
 
@@ -100,6 +107,7 @@ class ETagMiddleware implements MiddlewareInterface
                 if (! $lastModified || ! $filesize) {
                     return $response;
                 }
+
                 $etag = sprintf('W/"%x-%x"', $lastModified, $filesize);
                 break;
             case self::ETAG_VALIDATION_STRONG:

--- a/src/StaticResourceHandler/FileLocationRepository.php
+++ b/src/StaticResourceHandler/FileLocationRepository.php
@@ -100,8 +100,13 @@ class FileLocationRepository implements FileLocationRepositoryInterface
                 $directory
             ));
         }
-
-        if ($directory === '/' || $directory === '\\' || $directory === '\\\\') {
+        if ($directory === '/') {
+            return '/';
+        }
+        if ($directory === '\\') {
+            return '/';
+        }
+        if ($directory === '\\\\') {
             return '/';
         }
 
@@ -132,6 +137,7 @@ class FileLocationRepository implements FileLocationRepositoryInterface
                 }
             }
         }
+
         return null;
     }
 }

--- a/src/StaticResourceHandler/FileLocationRepositoryFactory.php
+++ b/src/StaticResourceHandler/FileLocationRepositoryFactory.php
@@ -14,7 +14,6 @@ use function array_merge;
 use function count;
 use function getcwd;
 use function is_array;
-use function is_countable;
 use function strlen;
 
 class FileLocationRepositoryFactory
@@ -38,7 +37,7 @@ class FileLocationRepositoryFactory
         // Add any configured mapped document roots
         $configMappedDocRoots = $config['mapped-document-roots'] ?? [];
 
-        if ((is_countable($configMappedDocRoots) ? count($configMappedDocRoots) : 0) > 0) {
+        if (count($configMappedDocRoots) > 0) {
             $mappedDocRoots = array_merge($mappedDocRoots, $configMappedDocRoots);
         }
 

--- a/src/StaticResourceHandler/FileLocationRepositoryFactory.php
+++ b/src/StaticResourceHandler/FileLocationRepositoryFactory.php
@@ -14,8 +14,8 @@ use function array_merge;
 use function count;
 use function getcwd;
 use function is_array;
+use function is_countable;
 use function strlen;
-use function strval;
 
 class FileLocationRepositoryFactory
 {
@@ -30,15 +30,15 @@ class FileLocationRepositoryFactory
         $configDocRoots = $config['document-root'] ?? getcwd() . '/public';
         $isArray        = is_array($configDocRoots);
 
-        $mappedDocRoots = ($isArray && (count($configDocRoots) > 0))
-            || (! $isArray && strlen(strval($configDocRoots)) > 0)
+        $mappedDocRoots = ($isArray && ($configDocRoots !== []))
+            || (! $isArray && strlen((string) $configDocRoots) > 0)
             ? ['/' => $configDocRoots]
             : [];
 
         // Add any configured mapped document roots
         $configMappedDocRoots = $config['mapped-document-roots'] ?? [];
 
-        if (count($configMappedDocRoots) > 0) {
+        if ((is_countable($configMappedDocRoots) ? count($configMappedDocRoots) : 0) > 0) {
             $mappedDocRoots = array_merge($mappedDocRoots, $configMappedDocRoots);
         }
 

--- a/src/StaticResourceHandler/GzipMiddleware.php
+++ b/src/StaticResourceHandler/GzipMiddleware.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Mezzio\Swoole\StaticResourceHandler;
 
 use Mezzio\Swoole\Exception;
+use Mezzio\Swoole\Exception\InvalidArgumentException;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
 
@@ -30,6 +31,7 @@ class GzipMiddleware implements MiddlewareInterface
 {
     /**
      * @psalm-var array<int, string>
+     * @var array<int, string>
      */
     public const COMPRESSION_CONTENT_ENCODING_MAP = [
         ZLIB_ENCODING_DEFLATE => 'deflate',
@@ -47,12 +49,13 @@ class GzipMiddleware implements MiddlewareInterface
     public function __construct(int $compressionLevel = 0)
     {
         if ($compressionLevel > 9) {
-            throw new Exception\InvalidArgumentException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 '%s only allows compression levels up to 9; received %d',
                 self::class,
                 $compressionLevel
             ));
         }
+
         $this->compressionLevel = $compressionLevel;
     }
 
@@ -91,7 +94,7 @@ class GzipMiddleware implements MiddlewareInterface
 
                 $countBytes = function_exists('mb_strlen') ? 'mb_strlen' : 'strlen';
                 $length     = 0;
-                while (feof($handle) !== true) {
+                while (! feof($handle)) {
                     $line = fgets($handle, 4096);
                     /** @psalm-suppress MixedAssignment */
                     $length += $countBytes($line);
@@ -131,6 +134,7 @@ class GzipMiddleware implements MiddlewareInterface
                 return ZLIB_ENCODING_DEFLATE;
             }
         }
+
         return null;
     }
 }

--- a/src/StaticResourceHandler/HeadMiddleware.php
+++ b/src/StaticResourceHandler/HeadMiddleware.php
@@ -19,6 +19,7 @@ class HeadMiddleware implements MiddlewareInterface
         if ($server['request_method'] !== 'HEAD') {
             return $response;
         }
+
         $response->disableContent();
         return $response;
     }

--- a/src/StaticResourceHandler/LastModifiedMiddleware.php
+++ b/src/StaticResourceHandler/LastModifiedMiddleware.php
@@ -76,7 +76,6 @@ class LastModifiedMiddleware implements MiddlewareInterface
      */
     private function isUnmodified(Request $request, string $lastModified): bool
     {
-        /** @var array<string,string> $request->header */
         $ifModifiedSince = $request->header['if-modified-since'] ?? '';
         if ('' === $ifModifiedSince) {
             return false;

--- a/src/StaticResourceHandler/LastModifiedMiddleware.php
+++ b/src/StaticResourceHandler/LastModifiedMiddleware.php
@@ -76,6 +76,7 @@ class LastModifiedMiddleware implements MiddlewareInterface
      */
     private function isUnmodified(Request $request, string $lastModified): bool
     {
+        /** @var array<string,string> $request->header */
         $ifModifiedSince = $request->header['if-modified-since'] ?? '';
         if ('' === $ifModifiedSince) {
             return false;

--- a/src/StaticResourceHandler/LastModifiedMiddleware.php
+++ b/src/StaticResourceHandler/LastModifiedMiddleware.php
@@ -41,8 +41,9 @@ class LastModifiedMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        $lastModified          = filemtime($filename) ?: 0;
-        $lastModified          = new DateTimeImmutable('@' . $lastModified, new DateTimeZone('GMT'));
+        $lastModified = filemtime($filename) ?: 0;
+        $lastModified = new DateTimeImmutable('@' . $lastModified, new DateTimeZone('GMT'));
+
         $formattedLastModified = IntlDateFormatter::formatObject(
             $lastModified,
             'EEEE dd-MMM-yy HH:mm:ss z'
@@ -65,6 +66,7 @@ class LastModifiedMiddleware implements MiddlewareInterface
                 return true;
             }
         }
+
         return false;
     }
 
@@ -78,11 +80,6 @@ class LastModifiedMiddleware implements MiddlewareInterface
         if ('' === $ifModifiedSince) {
             return false;
         }
-
-        if (new DateTimeImmutable($ifModifiedSince) < new DateTimeImmutable($lastModified)) {
-            return false;
-        }
-
-        return true;
+        return new DateTimeImmutable($ifModifiedSince) >= new DateTimeImmutable($lastModified);
     }
 }

--- a/src/StaticResourceHandler/MiddlewareInterface.php
+++ b/src/StaticResourceHandler/MiddlewareInterface.php
@@ -14,8 +14,7 @@ interface MiddlewareInterface
 {
     /**
      * @param string   $filename The discovered filename being returned.
-     * @param callable $next has the signature:
-     *     function (Request $request, string $filename) : StaticResourceResponse
+     * @param callable(Request,string):StaticResourceResponse $next
      */
     public function __invoke(
         Request $request,

--- a/src/StaticResourceHandler/MiddlewareQueue.php
+++ b/src/StaticResourceHandler/MiddlewareQueue.php
@@ -17,12 +17,11 @@ use function array_shift;
  */
 class MiddlewareQueue
 {
-    /** @var MiddlewareInterface[] */
-    private array $middleware;
-
-    public function __construct(array $middleware)
+    /**
+     * @param MiddlewareInterface[] $middleware
+     */
+    public function __construct(private array $middleware)
     {
-        $this->middleware = $middleware;
     }
 
     public function __invoke(Request $request, string $filename): StaticResourceResponse

--- a/src/StaticResourceHandler/StaticResourceResponse.php
+++ b/src/StaticResourceHandler/StaticResourceResponse.php
@@ -19,9 +19,6 @@ class StaticResourceResponse
 {
     private int $contentLength = 0;
 
-    /** @psalm-var array<string, string> */
-    private array $headers = [];
-
     /**
      * Does this response represent a failure to locate the requested resource
      * and/or that it cannot be requested?
@@ -31,24 +28,18 @@ class StaticResourceResponse
     /** @var callable */
     private $responseContentCallback;
 
-    private bool $sendContent = true;
-
-    private int $status;
-
     /**
      * @param null|callable $responseContentCallback Callback to use when emitting
      *     the response body content via Swoole. Must have the signature:
      *     function (SwooleHttpResponse $response, string $filename) : void
      */
     public function __construct(
-        int $status = 200,
-        array $headers = [],
-        bool $sendContent = true,
+        private int $status = 200,
+        /** @psalm-var array<string, string> */
+        private array $headers = [],
+        private bool $sendContent = true,
         ?callable $responseContentCallback = null
     ) {
-        $this->status                  = $status;
-        $this->headers                 = $headers;
-        $this->sendContent             = $sendContent;
         $this->responseContentCallback = $responseContentCallback
             ?: function (SwooleHttpResponse $response, string $filename): void {
                 $this->contentLength = filesize($filename);

--- a/src/StaticResourceHandler/ValidateRegexTrait.php
+++ b/src/StaticResourceHandler/ValidateRegexTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Mezzio\Swoole\StaticResourceHandler;
 
 use Mezzio\Swoole\Exception;
+use Mezzio\Swoole\Exception\InvalidArgumentException;
 
 use function preg_match;
 use function restore_error_handler;
@@ -34,7 +35,7 @@ trait ValidateRegexTrait
     {
         foreach ($regexList as $regex) {
             if (! $this->isValidRegex($regex)) {
-                throw new Exception\InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'The %s regex "%s" is invalid',
                     $type,
                     $regex

--- a/src/StaticResourceHandlerInterface.php
+++ b/src/StaticResourceHandlerInterface.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Swoole;
 
+use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
 use Swoole\Http\Request as SwooleHttpRequest;
 use Swoole\Http\Response as SwooleHttpResponse;
 
@@ -24,5 +25,5 @@ interface StaticResourceHandlerInterface
     public function processStaticResource(
         SwooleHttpRequest $request,
         SwooleHttpResponse $response
-    ): ?StaticResourceHandler\StaticResourceResponse;
+    ): ?StaticResourceResponse;
 }

--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -26,14 +26,13 @@ class SwooleEmitter implements EmitterInterface
 
     /**
      * @see https://www.swoole.co.uk/docs/modules/swoole-http-server/methods-properties#swoole-http-response-write
+     *
+     * @var int
      */
-    public const CHUNK_SIZE = 2_097_152; // 2 MB
+    public const CHUNK_SIZE = 2_097_152;
 
-    private SwooleHttpResponse $swooleResponse;
-
-    public function __construct(SwooleHttpResponse $response)
+    public function __construct(private SwooleHttpResponse $swooleResponse)
     {
-        $this->swooleResponse = $response;
     }
 
     /**
@@ -99,6 +98,7 @@ class SwooleEmitter implements EmitterInterface
         while (! $body->eof()) {
             $this->swooleResponse->write($body->read(static::CHUNK_SIZE));
         }
+
         $this->swooleResponse->end();
     }
 
@@ -108,7 +108,7 @@ class SwooleEmitter implements EmitterInterface
     private function emitCookies(ResponseInterface $response): void
     {
         foreach (SetCookies::fromResponse($response)->getAll() as $cookie) {
-            $sameSite = $cookie->getSameSite() ? substr($cookie->getSameSite()->asString(), 9) : '';
+            $sameSite = $cookie->getSameSite() !== null ? substr($cookie->getSameSite()->asString(), 9) : '';
 
             $this->swooleResponse->cookie(
                 $cookie->getName(),

--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -112,7 +112,7 @@ class SwooleEmitter implements EmitterInterface
 
             $this->swooleResponse->cookie(
                 $cookie->getName(),
-                $cookie->getValue(),
+                (string) $cookie->getValue(),
                 $cookie->getExpires(),
                 $cookie->getPath() ?: '/',
                 $cookie->getDomain() ?: '',

--- a/src/SwooleRequestHandlerRunner.php
+++ b/src/SwooleRequestHandlerRunner.php
@@ -73,47 +73,20 @@ final class SwooleRequestHandlerRunner implements RequestHandlerRunnerInterface
     public function run(): void
     {
         if ($this->httpServer->mode === SWOOLE_PROCESS) {
-            $this->httpServer->on('start', function (SwooleHttpServer $server): void {
-                $this->onStart($server);
-            });
-            $this->httpServer->on('shutdown', function (SwooleHttpServer $server): void {
-                $this->onShutdown($server);
-            });
+            $this->httpServer->on('start', [$this, 'onStart']);
+            $this->httpServer->on('shutdown', [$this, 'onShutdown']);
         }
 
-        $this->httpServer->on('managerstart', function (SwooleHttpServer $server): void {
-            $this->onManagerStart($server);
-        });
-        $this->httpServer->on('managerstop', function (SwooleHttpServer $server): void {
-            $this->onManagerStop($server);
-        });
-        $this->httpServer->on('workerstart', function (SwooleHttpServer $server, int $workerId): void {
-            $this->onWorkerStart($server, $workerId);
-        });
-        $this->httpServer->on('workerstop', function (SwooleHttpServer $server, int $workerId): void {
-            $this->onWorkerStop($server, $workerId);
-        });
-        $this->httpServer->on('workererror', function (
-            SwooleHttpServer $server,
-            int $workerId,
-            int $exitCode,
-            int $signal
-        ): void {
-            $this->onWorkerError($server, $workerId, $exitCode, $signal);
-        });
-        $this->httpServer->on('request', function (SwooleHttpRequest $request, SwooleHttpResponse $response): void {
-            $this->onRequest($request, $response);
-        });
-        $this->httpServer->on('beforereload', function (SwooleHttpServer $server): void {
-            $this->onBeforeReload($server);
-        });
-        $this->httpServer->on('afterreload', function (SwooleHttpServer $server): void {
-            $this->onAfterReload($server);
-        });
-        $this->httpServer->on('task', fn (SwooleHttpServer $server, array $args) => $this->onTask($server, $args));
-        $this->httpServer->on('finish', function (SwooleHttpServer $server, int $taskId, $returnData): void {
-            $this->onTaskFinish($server, $taskId, $returnData);
-        });
+        $this->httpServer->on('managerstart', [$this, 'onManagerStart']);
+        $this->httpServer->on('managerstop', [$this, 'onManagerStop']);
+        $this->httpServer->on('workerstart', [$this, 'onWorkerStart']);
+        $this->httpServer->on('workerstop', [$this, 'onWorkerStop']);
+        $this->httpServer->on('workererror', [$this, 'onWorkerError']);
+        $this->httpServer->on('request', [$this, 'onRequest']);
+        $this->httpServer->on('beforereload', [$this, 'onBeforeReload']);
+        $this->httpServer->on('afterreload', [$this, 'onAfterReload']);
+        $this->httpServer->on('task', [$this, 'onTask']);
+        $this->httpServer->on('finish', [$this, 'onTaskFinish']);
 
         $this->httpServer->start();
     }

--- a/src/Task/DeferredListener.php
+++ b/src/Task/DeferredListener.php
@@ -24,14 +24,11 @@ use Swoole\Http\Server as SwooleHttpServer;
  */
 final class DeferredListener
 {
-    private SwooleHttpServer $server;
-
     /** @var callable */
     private $listener;
 
-    public function __construct(SwooleHttpServer $server, callable $listener)
+    public function __construct(private SwooleHttpServer $server, callable $listener)
     {
-        $this->server   = $server;
         $this->listener = $listener;
     }
 

--- a/src/Task/DeferredServiceListener.php
+++ b/src/Task/DeferredServiceListener.php
@@ -19,18 +19,12 @@ use Swoole\Http\Server as SwooleHttpServer;
  */
 final class DeferredServiceListener
 {
-    private SwooleHttpServer $server;
-
     /** @var callable */
     private $listener;
 
-    private string $serviceName;
-
-    public function __construct(SwooleHttpServer $server, callable $listener, string $serviceName)
+    public function __construct(private SwooleHttpServer $server, callable $listener, private string $serviceName)
     {
-        $this->server      = $server;
-        $this->listener    = $listener;
-        $this->serviceName = $serviceName;
+        $this->listener = $listener;
     }
 
     public function __invoke(object $event): void

--- a/src/Task/ServiceBasedTask.php
+++ b/src/Task/ServiceBasedTask.php
@@ -28,16 +28,13 @@ final class ServiceBasedTask implements TaskInterface
 {
     private array $payload;
 
-    private string $serviceName;
-
     /**
      * @param array $payload Array of arguments for the $serviceName.
      * @psalm-param list<mixed> $payload
      */
-    public function __construct(string $serviceName, ...$payload)
+    public function __construct(private string $serviceName, ...$payload)
     {
-        $this->serviceName = $serviceName;
-        $this->payload     = $payload;
+        $this->payload = $payload;
     }
 
     /**

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -14,7 +14,6 @@ use ReturnTypeWillChange;
 use Webmozart\Assert\Assert;
 
 use function array_shift;
-use function get_class;
 use function is_callable;
 use function is_object;
 use function is_string;
@@ -81,7 +80,7 @@ final class Task implements TaskInterface
     private function serializeHandler($handler): string
     {
         if (is_object($handler)) {
-            return get_class($handler);
+            return $handler::class;
         }
 
         if (is_string($handler)) {

--- a/test/AssertResponseTrait.php
+++ b/test/AssertResponseTrait.php
@@ -22,6 +22,7 @@ trait AssertResponseTrait
     {
         $r = new ReflectionProperty($response, 'status');
         $r->setAccessible(true);
+
         $actual = $r->getValue($response);
 
         $message = $message ?: sprintf(
@@ -37,6 +38,7 @@ trait AssertResponseTrait
     {
         $r = new ReflectionProperty($response, 'headers');
         $r->setAccessible(true);
+
         $headers = $r->getValue($response);
 
         $message = $message ?: sprintf(
@@ -56,6 +58,7 @@ trait AssertResponseTrait
 
         $r = new ReflectionProperty($response, 'headers');
         $r->setAccessible(true);
+
         $headers = $r->getValue($response);
 
         Assert::assertArrayHasKey($name, $headers, $message);
@@ -70,6 +73,7 @@ trait AssertResponseTrait
 
         $r = new ReflectionProperty($response, 'headers');
         $r->setAccessible(true);
+
         $headers = $r->getValue($response);
 
         Assert::assertArrayNotHasKey($name, $headers, $message);
@@ -85,6 +89,7 @@ trait AssertResponseTrait
 
         $r = new ReflectionProperty($response, 'headers');
         $r->setAccessible(true);
+
         $headers = $r->getValue($response);
         $value   = $headers[$header];
 
@@ -108,6 +113,7 @@ trait AssertResponseTrait
 
         $r = new ReflectionProperty($response, 'headers');
         $r->setAccessible(true);
+
         $headers = $r->getValue($response);
         $value   = $headers[$header];
 
@@ -127,6 +133,7 @@ trait AssertResponseTrait
 
         $r = new ReflectionProperty($response, 'sendContent');
         $r->setAccessible(true);
+
         $value = $r->getValue($response);
         Assert::assertTrue($value, $message);
     }
@@ -137,6 +144,7 @@ trait AssertResponseTrait
 
         $r = new ReflectionProperty($response, 'sendContent');
         $r->setAccessible(true);
+
         $value = $r->getValue($response);
         Assert::assertFalse($value, $message);
     }

--- a/test/AttributeAssertionTrait.php
+++ b/test/AttributeAssertionTrait.php
@@ -35,7 +35,7 @@ trait AttributeAssertionTrait
      * @param object $instance Instance composing attribute to test
      */
     public static function assertAttributeEquals(
-        $expected,
+        mixed $expected,
         string $attributeName,
         $instance,
         string $message = '',
@@ -54,7 +54,7 @@ trait AttributeAssertionTrait
      * @param object $instance Instance composing attribute to test
      */
     public static function assertAttributeInstanceOf(
-        $expected,
+        mixed $expected,
         string $attributeName,
         $instance,
         string $message = ''
@@ -68,8 +68,12 @@ trait AttributeAssertionTrait
      * @param mixed  $expected Expected value
      * @param object $instance Instance composing attribute to test
      */
-    public static function assertAttributeSame($expected, string $attributeName, $instance, string $message = ''): void
-    {
+    public static function assertAttributeSame(
+        mixed $expected,
+        string $attributeName,
+        $instance,
+        string $message = ''
+    ): void {
         $r = new ReflectionProperty($instance, $attributeName);
         $r->setAccessible(true);
         Assert::assertSame($expected, $r->getValue($instance), $message);

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -30,11 +30,8 @@ class ReloadCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
-    /**
-     * @var InputInterface|MockObject
-     * @psalm-var MockObject&InputInterface
-     */
-    private $input;
+    /** @psalm-var MockObject&InputInterface */
+    private InputInterface|MockObject $input;
 
     /**
      * @var OutputInterface|MockObject
@@ -49,10 +46,9 @@ class ReloadCommandTest extends TestCase
     }
 
     /**
-     * @return Application|MockObject
      * @psalm-return MockObject&Application
      */
-    public function mockApplication()
+    public function mockApplication(): Application|MockObject
     {
         $helperSet   = $this->createMock(HelperSet::class);
         $application = $this->createMock(Application::class);

--- a/test/Command/StartCommandTest.php
+++ b/test/Command/StartCommandTest.php
@@ -13,6 +13,7 @@ use Mezzio\MiddlewareFactory;
 use Mezzio\Swoole\Command\StartCommand;
 use Mezzio\Swoole\PidManager;
 use MezzioTest\Swoole\AttributeAssertionTrait;
+use MezzioTest\Swoole\Command\TestAsset\HttpServer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -36,17 +37,11 @@ class StartCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
-    /**
-     * @var ContainerInterface|MockObject
-     * @psalm-var MockObject&ContainerInterface
-     */
-    private $container;
+    /** @psalm-var MockObject&ContainerInterface */
+    private ContainerInterface|MockObject $container;
 
-    /**
-     * @var InputInterface|MockObject
-     * @psalm-var MockObject&InputInterface
-     */
-    private $input;
+    /** @psalm-var MockObject&InputInterface */
+    private InputInterface|MockObject $input;
 
     private string $originalIncludePath;
 
@@ -56,11 +51,8 @@ class StartCommandTest extends TestCase
      */
     private $output;
 
-    /**
-     * @var PidManager|MockObject
-     * @psalm-var MockObject&PidManager
-     */
-    private $pidManager;
+    /** @psalm-var MockObject&PidManager */
+    private PidManager|MockObject $pidManager;
 
     protected function setUp(): void
     {
@@ -218,7 +210,7 @@ class StartCommandTest extends TestCase
      */
     public function testExecuteRunsApplicationIfServerIsNotCurrentlyRunning(array $pids): void
     {
-        $httpServer        = $this->createMock(TestAsset\HttpServer::class);
+        $httpServer        = $this->createMock(HttpServer::class);
         $middlewareFactory = $this->createMock(MiddlewareFactory::class);
         $application       = $this->createMock(Application::class);
 
@@ -304,7 +296,7 @@ class StartCommandTest extends TestCase
 
     private function prepareSuccessfulStartCommand(array $pids): array
     {
-        $httpServer        = $this->createMock(TestAsset\HttpServer::class);
+        $httpServer        = $this->createMock(HttpServer::class);
         $middlewareFactory = $this->createMock(MiddlewareFactory::class);
         $application       = $this->createMock(Application::class);
 

--- a/test/Command/StatusCommandTest.php
+++ b/test/Command/StatusCommandTest.php
@@ -24,11 +24,8 @@ class StatusCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
-    /**
-     * @var InputInterface|MockObject
-     * @psalm-var MockObject&InputInterface
-     */
-    private $input;
+    /** @psalm-var MockObject&InputInterface */
+    private InputInterface|MockObject $input;
 
     /**
      * @var OutputInterface|MockObject
@@ -36,11 +33,8 @@ class StatusCommandTest extends TestCase
      */
     private $output;
 
-    /**
-     * @var PidManager|MockObject
-     * @psalm-var MockObject&PidManager
-     */
-    private $pidManager;
+    /** @psalm-var MockObject&PidManager */
+    private PidManager|MockObject $pidManager;
 
     protected function setUp(): void
     {

--- a/test/Command/StopCommandTest.php
+++ b/test/Command/StopCommandTest.php
@@ -24,11 +24,8 @@ class StopCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
-    /**
-     * @var InputInterface|MockObject
-     * @psalm-var MockObject&InputInterface
-     */
-    private $input;
+    /** @psalm-var MockObject&InputInterface */
+    private InputInterface|MockObject $input;
 
     /**
      * @var OutputInterface|MockObject
@@ -36,11 +33,8 @@ class StopCommandTest extends TestCase
      */
     private $output;
 
-    /**
-     * @var PidManager|MockObject
-     * @psalm-var MockObject&PidManager
-     */
-    private $pidManager;
+    /** @psalm-var MockObject&PidManager */
+    private PidManager|MockObject $pidManager;
 
     protected function setUp(): void
     {

--- a/test/Command/TestAsset/HttpServer.php
+++ b/test/Command/TestAsset/HttpServer.php
@@ -23,4 +23,5 @@ interface HttpServer
 {
     public function set(array $options): void;
 }
+
 // phpcs:enable

--- a/test/Command/TestAsset/config/pipeline.php
+++ b/test/Command/TestAsset/config/pipeline.php
@@ -1,10 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
- */
-
 declare(strict_types=1);
+
+namespace MezzioTest\Swoole\Command\TestAsset\config;
 
 use Mezzio\Application;
 use Mezzio\MiddlewareFactory;

--- a/test/Command/TestAsset/config/routes.php
+++ b/test/Command/TestAsset/config/routes.php
@@ -1,10 +1,8 @@
 <?php
 
-/**
- * @see       https://github.com/mezzio/mezzio-swoole for the canonical source repository
- */
-
 declare(strict_types=1);
+
+namespace MezzioTest\Swoole\Command\TestAsset\config;
 
 use Mezzio\Application;
 use Mezzio\MiddlewareFactory;

--- a/test/Event/RequestHandlerRequestListenerTest.php
+++ b/test/Event/RequestHandlerRequestListenerTest.php
@@ -49,29 +49,31 @@ class RequestHandlerRequestListenerTest extends TestCase
     /** @psalm-var SwooleHttpResponse&MockObject */
     private SwooleHttpResponse $swooleResponse;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        $this->swooleRequest  = $this->createMock(SwooleHttpRequest::class);
-        $this->swooleResponse = $this->createMock(SwooleHttpResponse::class);
-
-        $this->request  = $request = $this->createMock(ServerRequestInterface::class);
-        $requestFactory = function (SwooleHttpRequest $swooleRequest) use ($request): ServerRequestInterface {
-            if ($this->exceptionToThrowOnRequestGeneration) {
+        $this->swooleRequest    = $this->createMock(SwooleHttpRequest::class);
+        $this->swooleResponse   = $this->createMock(SwooleHttpResponse::class);
+        $this->request          = $this->createMock(ServerRequestInterface::class);
+        $request                = $this->request;
+        $requestFactory         = function (SwooleHttpRequest $swooleRequest) use ($request): ServerRequestInterface {
+            if ($this->exceptionToThrowOnRequestGeneration !== null) {
                 throw $this->exceptionToThrowOnRequestGeneration;
             }
+
             return $request;
         };
-
-        $this->errorResponse    = $errorResponse = $this->createMock(ResponseInterface::class);
+        $this->errorResponse    = $this->createMock(ResponseInterface::class);
+        $errorResponse          = $this->errorResponse;
         $errorResponseGenerator = function (Throwable $e) use ($errorResponse): ResponseInterface {
-            if ($this->exceptionToThrowOnRequestGeneration) {
+            if ($this->exceptionToThrowOnRequestGeneration !== null) {
                 TestCase::assertSame($this->exceptionToThrowOnRequestGeneration, $e);
             }
+
             return $errorResponse;
         };
-
-        $this->emitter  = $emitter = $this->createMock(SwooleEmitter::class);
-        $emitterFactory = static fn(SwooleHttpResponse $response): SwooleEmitter => $emitter;
+        $this->emitter          = $this->createMock(SwooleEmitter::class);
+        $emitter                = $this->emitter;
+        $emitterFactory         = static fn(SwooleHttpResponse $response): SwooleEmitter => $emitter;
 
         $this->requestHandler = $this->createMock(RequestHandlerInterface::class);
         $this->logger         = $this->createMock(AccessLogInterface::class);

--- a/test/Event/ServerStartListenerTest.php
+++ b/test/Event/ServerStartListenerTest.php
@@ -23,13 +23,13 @@ class ServerStartListenerTest extends TestCase
 {
     private string $cwd;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         ServerStartListener::$setProcessName = 'swoole_set_process_name';
         $this->cwd                           = getcwd();
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         ServerStartListener::$setProcessName = 'swoole_set_process_name';
         chdir($this->cwd);

--- a/test/Event/StaticResourceRequestListenerTest.php
+++ b/test/Event/StaticResourceRequestListenerTest.php
@@ -22,13 +22,17 @@ class StaticResourceRequestListenerTest extends TestCase
 {
     /** @psalm-var StaticResourceHandlerInterface&MockObject */
     private StaticResourceHandlerInterface $handler;
+
     private StaticResourceRequestListener $listener;
+
     /** @psalm-var AccessLogInterface&MockObject */
     private AccessLogInterface $logger;
+
     private SwooleHttpRequest $swooleRequest;
+
     private SwooleHttpResponse $swooleResponse;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->swooleRequest  = $this->createMock(SwooleHttpRequest::class);
         $this->swooleResponse = $this->createMock(SwooleHttpResponse::class);

--- a/test/Event/SwooleListenerProviderFactoryTest.php
+++ b/test/Event/SwooleListenerProviderFactoryTest.php
@@ -35,9 +35,8 @@ class SwooleListenerProviderFactoryTest extends TestCase
 
     /**
      * @dataProvider invalidListenerTypes
-     * @param mixed $invalidListener
      */
-    public function testFactoryRaisesErrorForNonCallableNonStringListeners($invalidListener): void
+    public function testFactoryRaisesErrorForNonCallableNonStringListeners(mixed $invalidListener): void
     {
         $config    = [
             'mezzio-swoole' => [

--- a/test/Event/SwooleListenerProviderTest.php
+++ b/test/Event/SwooleListenerProviderTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MezzioTest\Swoole\Event;
 
 use Mezzio\Swoole\Event\SwooleListenerProvider;
+use MezzioTest\Swoole\Event\TestAsset\TestEvent;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -18,18 +19,18 @@ class SwooleListenerProviderTest extends TestCase
 {
     public function testProviderAllowsListenerRegistrationAndReturnsListenersBasedOnEventType(): void
     {
-        $listenerForTestEvent = static function (TestAsset\TestEvent $e): void {
+        $listenerForTestEvent = static function (TestEvent $e): void {
         };
         $listenerForStdclass  = static function (stdClass $e): void {
         };
 
         $provider = new SwooleListenerProvider();
-        $provider->addListener(TestAsset\TestEvent::class, $listenerForTestEvent);
+        $provider->addListener(TestEvent::class, $listenerForTestEvent);
         $provider->addListener(stdClass::class, $listenerForStdclass);
 
         $this->assertSame(
             [$listenerForTestEvent],
-            iterator_to_array($provider->getListenersForEvent(new TestAsset\TestEvent()))
+            iterator_to_array($provider->getListenersForEvent(new TestEvent()))
         );
 
         $this->assertSame(
@@ -40,16 +41,16 @@ class SwooleListenerProviderTest extends TestCase
 
     public function testProviderDoesNotAllowDuplicateRegistration(): void
     {
-        $listenerForTestEvent = static function (TestAsset\TestEvent $e): void {
+        $listenerForTestEvent = static function (TestEvent $e): void {
         };
 
         $provider = new SwooleListenerProvider();
-        $provider->addListener(TestAsset\TestEvent::class, $listenerForTestEvent);
-        $provider->addListener(TestAsset\TestEvent::class, $listenerForTestEvent);
+        $provider->addListener(TestEvent::class, $listenerForTestEvent);
+        $provider->addListener(TestEvent::class, $listenerForTestEvent);
 
         $this->assertSame(
             [$listenerForTestEvent],
-            iterator_to_array($provider->getListenersForEvent(new TestAsset\TestEvent()))
+            iterator_to_array($provider->getListenersForEvent(new TestEvent()))
         );
     }
 }

--- a/test/Event/WorkerStartListenerTest.php
+++ b/test/Event/WorkerStartListenerTest.php
@@ -23,13 +23,13 @@ class WorkerStartListenerTest extends TestCase
 {
     private string $cwd;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->cwd                           = getcwd();
         WorkerStartListener::$setProcessName = 'swoole_process_name';
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         chdir($this->cwd);
         WorkerStartListener::$setProcessName = 'swoole_process_name';

--- a/test/HotCodeReload/FileWatcher/InotifyFileWatcherTest.php
+++ b/test/HotCodeReload/FileWatcher/InotifyFileWatcherTest.php
@@ -32,6 +32,7 @@ class InotifyFileWatcherTest extends TestCase
         if (false === $file) {
             static::markTestSkipped('Unable to create a temporary file');
         }
+
         $this->file = $file;
 
         parent::setUp();

--- a/test/HttpServerFactoryTest.php
+++ b/test/HttpServerFactoryTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Swoole\Event as SwooleEvent;
+use Swoole\Http\Request;
+use Swoole\Http\Response;
 use Swoole\Http\Server as SwooleServer;
 use Swoole\Process;
 use Swoole\Runtime as SwooleRuntime;
@@ -298,10 +300,10 @@ class HttpServerFactoryTest extends TestCase
                     $server->stop();
                     $server->shutdown();
                 });
-                $swooleServer->on('Request', static function ($req, $rep): void {
+                $swooleServer->on('Request', static function (Request $req, Response $rep): void {
                     // noop
                 });
-                $swooleServer->on('Packet', static function (SwooleServer $server, $data, $clientInfo): void {
+                $swooleServer->on('Packet', static function (SwooleServer $server, string $data, array $clientInfo): void {
                     // noop
                 });
                 $swooleServer->start();

--- a/test/Log/AccessLogDataMapTest.php
+++ b/test/Log/AccessLogDataMapTest.php
@@ -21,17 +21,11 @@ use function date_default_timezone_get;
 
 class AccessLogDataMapTest extends TestCase
 {
-    /**
-     * @var SwooleHttpRequest|MockObject
-     * @psalm-var MockObject&SwooleHttpRequest
-     */
-    private $request;
+    /** @psalm-var MockObject&SwooleHttpRequest */
+    private SwooleHttpRequest|MockObject $request;
 
-    /**
-     * @var ResponseInterface|MockObject
-     * @psalm-var MockObject&ResponseInterface
-     */
-    private $response;
+    /** @psalm-var MockObject&ResponseInterface */
+    private ResponseInterface|MockObject $response;
 
     protected function setUp(): void
     {

--- a/test/Log/AccessLogFactoryTest.php
+++ b/test/Log/AccessLogFactoryTest.php
@@ -31,11 +31,8 @@ class AccessLogFactoryTest extends TestCase
      */
     private $logger;
 
-    /**
-     * @var AccessLogFormatterInterface|MockObject
-     * @psalm-var AccessLogFormatterInterface&MockObject
-     */
-    private $formatter;
+    /** @psalm-var AccessLogFormatterInterface&MockObject */
+    private AccessLogFormatterInterface|MockObject $formatter;
 
     protected function setUp(): void
     {
@@ -126,6 +123,7 @@ class AccessLogFactoryTest extends TestCase
 
         $r = new ReflectionProperty($logger, 'formatter');
         $r->setAccessible(true);
+
         $formatter = $r->getValue($logger);
         Assert::isInstanceOf($formatter, AccessLogFormatterInterface::class);
 

--- a/test/Log/Psr3AccessLogDecoratorTest.php
+++ b/test/Log/Psr3AccessLogDecoratorTest.php
@@ -26,35 +26,20 @@ class Psr3AccessLogDecoratorTest extends TestCase
 {
     use AttributeAssertionTrait;
 
-    /**
-     * @var LoggerInterface|MockObject
-     * @psalm-var MockObject&LoggerInterface
-     */
-    private $psr3Logger;
+    /** @psalm-var MockObject&LoggerInterface */
+    private LoggerInterface|MockObject $psr3Logger;
 
-    /**
-     * @var AccessLogFormatterInterface|MockObject
-     * @psalm-var MockObject&AccessLogFormatterInterface
-     */
-    private $formatter;
+    /** @psalm-var MockObject&AccessLogFormatterInterface */
+    private AccessLogFormatterInterface|MockObject $formatter;
 
-    /**
-     * @var Request|MockObject
-     * @psalm-var MockObject&Request
-     */
-    private $request;
+    /** @psalm-var MockObject&Request */
+    private Request|MockObject $request;
 
-    /**
-     * @var Psr7Response|MockObject
-     * @psalm-var MockObject&Psr7Response
-     */
-    private $psr7Response;
+    /** @psalm-var MockObject&Psr7Response */
+    private Psr7Response|MockObject $psr7Response;
 
-    /**
-     * @var StaticResourceResponse|MockObject
-     * @psalm-var MockObject&StaticResourceResponse
-     */
-    private $staticResponse;
+    /** @psalm-var MockObject&StaticResourceResponse */
+    private StaticResourceResponse|MockObject $staticResponse;
 
     protected function setUp(): void
     {
@@ -91,21 +76,18 @@ class Psr3AccessLogDecoratorTest extends TestCase
     public function testProxiesToPsr3Methods(string $method): void
     {
         $logger = new Psr3AccessLogDecorator($this->psr3Logger, $this->formatter);
-        switch ($method) {
-            case 'log':
-                $this->psr3Logger
-                    ->expects($this->once())
-                    ->method('log')
-                    ->with(LogLevel::DEBUG, 'message', ['foo' => 'bar']);
-                $this->assertNull($logger->log(LogLevel::DEBUG, 'message', ['foo' => 'bar']));
-                break;
-            default:
-                $this->psr3Logger
-                    ->expects($this->once())
-                    ->method($method)
-                    ->with('message', ['foo' => 'bar']);
-                $this->assertNull($logger->$method('message', ['foo' => 'bar']));
-                break;
+        if ($method === 'log') {
+            $this->psr3Logger
+                ->expects($this->once())
+                ->method('log')
+                ->with(LogLevel::DEBUG, 'message', ['foo' => 'bar']);
+            $this->assertNull($logger->log(LogLevel::DEBUG, 'message', ['foo' => 'bar']));
+        } else {
+            $this->psr3Logger
+                ->expects($this->once())
+                ->method($method)
+                ->with('message', ['foo' => 'bar']);
+            $this->assertNull($logger->$method('message', ['foo' => 'bar']));
         }
     }
 
@@ -137,8 +119,8 @@ class Psr3AccessLogDecoratorTest extends TestCase
         $this->formatter
             ->method('format')
             ->with($this->callback(
-                fn(AccessLogDataMap $mapper) =>
-                    $this->request === $this->getPropertyForInstance('request', $mapper) &&
+                fn (AccessLogDataMap $mapper) =>
+                $this->request === $this->getPropertyForInstance('request', $mapper) &&
                     $this->staticResponse === $this->getPropertyForInstance('staticResource', $mapper) &&
                     false === $this->getPropertyForInstance('useHostnameLookups', $mapper)
             ))
@@ -166,13 +148,13 @@ class Psr3AccessLogDecoratorTest extends TestCase
         $this->psr7Response->method('getStatusCode')->willReturn($status);
 
         $this->formatter
-             ->method('format')
-             ->with($this->callback(
-                 fn(AccessLogDataMap $mapper) =>
-                     $this->request === $this->getPropertyForInstance('request', $mapper) &&
-                     $this->psr7Response === $this->getPropertyForInstance('psrResponse', $mapper) &&
-                     false === $this->getPropertyForInstance('useHostnameLookups', $mapper)
-             ))
+            ->method('format')
+            ->with($this->callback(
+                fn (AccessLogDataMap $mapper) =>
+                $this->request === $this->getPropertyForInstance('request', $mapper) &&
+                    $this->psr7Response === $this->getPropertyForInstance('psrResponse', $mapper) &&
+                    false === $this->getPropertyForInstance('useHostnameLookups', $mapper)
+            ))
             ->willReturn($expected);
 
         $this->psr3Logger

--- a/test/PidManagerFactoryTest.php
+++ b/test/PidManagerFactoryTest.php
@@ -15,11 +15,8 @@ use Psr\Container\ContainerInterface;
 
 class PidManagerFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|MockObject
-     * @psalm-var MockObject&ContainerInterface
-     */
-    private $container;
+    /** @psalm-var MockObject&ContainerInterface */
+    private ContainerInterface|MockObject $container;
 
     private PidManagerFactory $pidManagerFactory;
 

--- a/test/StaticMappedResourceHandlerFactoryTest.php
+++ b/test/StaticMappedResourceHandlerFactoryTest.php
@@ -32,17 +32,11 @@ class StaticMappedResourceHandlerFactoryTest extends TestCase
 {
     use AttributeAssertionTrait;
 
-    /**
-     * @var ContainerInterface|MockObject
-     * @psalm-var MockObject&ContainerInterface
-     */
-    private $container;
+    /** @psalm-var MockObject&ContainerInterface */
+    private ContainerInterface|MockObject $container;
 
-    /**
-     * @var FileLocationRepositoryInterface|MockObject
-     * @psalm-var MockObject&FileLocationRepositoryInterface
-     */
-    private $fileLocRepo;
+    /** @psalm-var MockObject&FileLocationRepositoryInterface */
+    private FileLocationRepositoryInterface|MockObject $fileLocRepo;
 
     protected function setUp(): void
     {
@@ -71,6 +65,7 @@ class StaticMappedResourceHandlerFactoryTest extends TestCase
                 return $middleware;
             }
         }
+
         $this->fail(sprintf(
             'Could not find middleware of type %s',
             $type
@@ -133,6 +128,7 @@ class StaticMappedResourceHandlerFactoryTest extends TestCase
 
         $r = new ReflectionProperty($handler, 'middleware');
         $r->setAccessible(true);
+
         $middleware = $r->getValue($handler);
 
         Assert::isList($middleware);

--- a/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
+++ b/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
@@ -57,6 +57,7 @@ class ContentTypeFilterMiddlewareTest extends TestCase
             'txt' => 'text/plain',
         ]);
 
+        /** @psalm-suppress InvalidArgument */
         $response = $middleware($this->request, __DIR__ . '/../image.png', $next);
 
         $this->assertTrue($response->isFailure());
@@ -65,7 +66,7 @@ class ContentTypeFilterMiddlewareTest extends TestCase
     public function testMiddlewareAddsContentTypeToResponseWhenResourceLocatedAndAllowed(): void
     {
         $expected   = new StaticResourceResponse();
-        $next       = static fn(Request $request, string $filename): StaticResourceResponse => $expected;
+        $next       = static fn (Request $request, string $filename): StaticResourceResponse => $expected;
         $middleware = new ContentTypeFilterMiddleware();
 
         $response = $middleware($this->request, __DIR__ . '/../TestAsset/image.png', $next);

--- a/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
+++ b/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
@@ -21,11 +21,8 @@ class ContentTypeFilterMiddlewareTest extends TestCase
     use AssertResponseTrait;
     use AttributeAssertionTrait;
 
-    /**
-     * @var Request|MockObject
-     * @psalm-var MockObject&Request
-     */
-    private $request;
+    /** @psalm-var MockObject&Request */
+    private Request|MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/ETagMiddlewareTest.php
+++ b/test/StaticResourceHandler/ETagMiddlewareTest.php
@@ -30,11 +30,8 @@ class ETagMiddlewareTest extends TestCase
     /** @var callable */
     private $next;
 
-    /**
-     * @var Request|MockObject
-     * @psalm-var MockObject&Request
-     */
-    private $request;
+    /** @psalm-var MockObject&Request */
+    private Request|MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
+++ b/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
@@ -22,11 +22,8 @@ use function time;
 
 class FileLocationRepositoryFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|MockObject
-     * @psalm-var MockObject&ContainerInterface
-     */
-    private $mockContainer;
+    /** @psalm-var MockObject&ContainerInterface */
+    private ContainerInterface|MockObject $mockContainer;
 
     private FileLocationRepositoryFactory $fileLocRepoFactory;
 

--- a/test/StaticResourceHandler/GzipMiddlewareTest.php
+++ b/test/StaticResourceHandler/GzipMiddlewareTest.php
@@ -30,17 +30,11 @@ class GzipMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /**
-     * @var StaticResourceResponse|MockObject
-     * @psalm-var StaticResourceResponse&MockObject
-     */
-    private $staticResponse;
+    /** @psalm-var StaticResourceResponse&MockObject */
+    private StaticResourceResponse|MockObject $staticResponse;
 
-    /**
-     * @var SwooleHttpRequest|MockObject
-     * @psalm-var SwooleHttpRequest&MockObject
-     */
-    private $swooleRequest;
+    /** @psalm-var SwooleHttpRequest&MockObject */
+    private SwooleHttpRequest|MockObject $swooleRequest;
 
     /** @var callable */
     private $next;
@@ -149,6 +143,7 @@ class GzipMiddlewareTest extends TestCase
 
         $r = new ReflectionProperty($response, 'responseContentCallback');
         $r->setAccessible(true);
+
         $callback = $r->getValue($response);
         Assert::isCallable($callback);
 

--- a/test/StaticResourceHandler/HeadMiddlewareTest.php
+++ b/test/StaticResourceHandler/HeadMiddlewareTest.php
@@ -19,11 +19,8 @@ class HeadMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /**
-     * @var Request|MockObject
-     * @psalm-var MockObject&Request
-     */
-    private $request;
+    /** @psalm-var MockObject&Request */
+    private Request|MockObject $request;
 
     /** @var callable */
     private $next;

--- a/test/StaticResourceHandler/IntegrationMappedTest.php
+++ b/test/StaticResourceHandler/IntegrationMappedTest.php
@@ -38,11 +38,8 @@ class IntegrationMappedTest extends TestCase
 {
     use FormatTimestampTrait;
 
-    /**
-     * @var FileLocationRepositoryInterface|MockObject
-     * @psalm-var MockObject&FileLocationRepositoryInterface
-     */
-    private $mockFileLocRepo;
+    /** @psalm-var MockObject&FileLocationRepositoryInterface */
+    private FileLocationRepositoryInterface|MockObject $mockFileLocRepo;
 
     /** @psalm-var non-empty-string */
     private string $assetPath;

--- a/test/StaticResourceHandler/IntegrationTest.php
+++ b/test/StaticResourceHandler/IntegrationTest.php
@@ -9,6 +9,15 @@ declare(strict_types=1);
 namespace MezzioTest\Swoole\StaticResourceHandler;
 
 use Mezzio\Swoole\StaticResourceHandler;
+use Mezzio\Swoole\StaticResourceHandler\CacheControlMiddleware;
+use Mezzio\Swoole\StaticResourceHandler\ClearStatCacheMiddleware;
+use Mezzio\Swoole\StaticResourceHandler\ContentTypeFilterMiddleware;
+use Mezzio\Swoole\StaticResourceHandler\ETagMiddleware;
+use Mezzio\Swoole\StaticResourceHandler\GzipMiddleware;
+use Mezzio\Swoole\StaticResourceHandler\HeadMiddleware;
+use Mezzio\Swoole\StaticResourceHandler\LastModifiedMiddleware;
+use Mezzio\Swoole\StaticResourceHandler\MethodNotAllowedMiddleware;
+use Mezzio\Swoole\StaticResourceHandler\OptionsMiddleware;
 use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
 use MezzioTest\Swoole\FormatTimestampTrait;
 use PHPUnit\Framework\TestCase;
@@ -70,10 +79,10 @@ class IntegrationTest extends TestCase
         $response->expects($this->never())->method('sendfile');
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
         ]);
 
         $result = $handler->processStaticResource($request, $response);
@@ -101,10 +110,10 @@ class IntegrationTest extends TestCase
         $response->expects($this->never())->method('sendfile');
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
         ]);
 
         $result = $handler->processStaticResource($request, $response);
@@ -141,17 +150,17 @@ class IntegrationTest extends TestCase
         $response->expects($this->once())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([
                 '/\.txt$/' => ['public', 'no-transform'],
             ]),
-            new StaticResourceHandler\LastModifiedMiddleware(['/\.txt$/']),
-            new StaticResourceHandler\ETagMiddleware(['/\.txt$/']),
+            new LastModifiedMiddleware(['/\.txt$/']),
+            new ETagMiddleware(['/\.txt$/']),
         ]);
 
         $result = $handler->processStaticResource($request, $response);
@@ -187,19 +196,19 @@ class IntegrationTest extends TestCase
         $response->expects($this->never())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([
                 '/\.txt$/' => ['public', 'no-transform'],
             ]),
-            new StaticResourceHandler\LastModifiedMiddleware(['/\.txt$/']),
-            new StaticResourceHandler\ETagMiddleware(
+            new LastModifiedMiddleware(['/\.txt$/']),
+            new ETagMiddleware(
                 ['/\.txt$/'],
-                StaticResourceHandler\ETagMiddleware::ETAG_VALIDATION_WEAK
+                ETagMiddleware::ETAG_VALIDATION_WEAK
             ),
         ]);
 
@@ -237,19 +246,19 @@ class IntegrationTest extends TestCase
         $response->expects($this->never())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([
                 '/\.txt$/' => ['public', 'no-transform'],
             ]),
-            new StaticResourceHandler\LastModifiedMiddleware(['/\.txt$/']),
-            new StaticResourceHandler\ETagMiddleware(
+            new LastModifiedMiddleware(['/\.txt$/']),
+            new ETagMiddleware(
                 ['/\.txt$/'],
-                StaticResourceHandler\ETagMiddleware::ETAG_VALIDATION_WEAK
+                ETagMiddleware::ETAG_VALIDATION_WEAK
             ),
         ]);
 
@@ -288,17 +297,17 @@ class IntegrationTest extends TestCase
         $response->expects($this->once())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([
                 '/\.txt$/' => ['public', 'no-transform'],
             ]),
-            new StaticResourceHandler\LastModifiedMiddleware([]),
-            new StaticResourceHandler\ETagMiddleware([]),
+            new LastModifiedMiddleware([]),
+            new ETagMiddleware([]),
         ]);
 
         $result = $handler->processStaticResource($request, $response);
@@ -335,17 +344,17 @@ class IntegrationTest extends TestCase
         $response->expects($this->never())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([
                 '/\.txt$/' => ['public', 'no-transform'],
             ]),
-            new StaticResourceHandler\LastModifiedMiddleware([]),
-            new StaticResourceHandler\ETagMiddleware([]),
+            new LastModifiedMiddleware([]),
+            new ETagMiddleware([]),
         ]);
 
         $result = $handler->processStaticResource($request, $response);
@@ -380,17 +389,17 @@ class IntegrationTest extends TestCase
         $response->expects($this->never())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([]),
-            new StaticResourceHandler\LastModifiedMiddleware([]),
-            new StaticResourceHandler\ETagMiddleware(
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([]),
+            new LastModifiedMiddleware([]),
+            new ETagMiddleware(
                 ['/\.txt$/'],
-                StaticResourceHandler\ETagMiddleware::ETAG_VALIDATION_WEAK
+                ETagMiddleware::ETAG_VALIDATION_WEAK
             ),
         ]);
 
@@ -426,17 +435,17 @@ class IntegrationTest extends TestCase
         $response->expects($this->never())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([]),
-            new StaticResourceHandler\LastModifiedMiddleware([]),
-            new StaticResourceHandler\ETagMiddleware(
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([]),
+            new LastModifiedMiddleware([]),
+            new ETagMiddleware(
                 ['/\.txt$/'],
-                StaticResourceHandler\ETagMiddleware::ETAG_VALIDATION_WEAK
+                ETagMiddleware::ETAG_VALIDATION_WEAK
             ),
         ]);
 
@@ -470,17 +479,17 @@ class IntegrationTest extends TestCase
         $response->expects($this->once())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([]),
-            new StaticResourceHandler\LastModifiedMiddleware([]),
-            new StaticResourceHandler\ETagMiddleware(
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([]),
+            new LastModifiedMiddleware([]),
+            new ETagMiddleware(
                 ['/\.txt$/'],
-                StaticResourceHandler\ETagMiddleware::ETAG_VALIDATION_STRONG
+                ETagMiddleware::ETAG_VALIDATION_STRONG
             ),
         ]);
 
@@ -516,15 +525,15 @@ class IntegrationTest extends TestCase
         $response->expects($this->never())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([]),
-            new StaticResourceHandler\LastModifiedMiddleware(['/\.txt$/']),
-            new StaticResourceHandler\ETagMiddleware([]),
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([]),
+            new LastModifiedMiddleware(['/\.txt$/']),
+            new ETagMiddleware([]),
         ]);
 
         $result = $handler->processStaticResource($request, $response);
@@ -562,15 +571,15 @@ class IntegrationTest extends TestCase
         $response->expects($this->once())->method('sendfile')->with($file);
 
         $handler = new StaticResourceHandler($this->docRoot, [
-            new StaticResourceHandler\ContentTypeFilterMiddleware(),
-            new StaticResourceHandler\MethodNotAllowedMiddleware(),
-            new StaticResourceHandler\OptionsMiddleware(),
-            new StaticResourceHandler\HeadMiddleware(),
-            new StaticResourceHandler\GzipMiddleware(0),
-            new StaticResourceHandler\ClearStatCacheMiddleware(3600),
-            new StaticResourceHandler\CacheControlMiddleware([]),
-            new StaticResourceHandler\LastModifiedMiddleware(['/\.txt$/']),
-            new StaticResourceHandler\ETagMiddleware([]),
+            new ContentTypeFilterMiddleware(),
+            new MethodNotAllowedMiddleware(),
+            new OptionsMiddleware(),
+            new HeadMiddleware(),
+            new GzipMiddleware(0),
+            new ClearStatCacheMiddleware(3600),
+            new CacheControlMiddleware([]),
+            new LastModifiedMiddleware(['/\.txt$/']),
+            new ETagMiddleware([]),
         ]);
 
         $result = $handler->processStaticResource($request, $response);

--- a/test/StaticResourceHandler/LastModifiedMiddlewareTest.php
+++ b/test/StaticResourceHandler/LastModifiedMiddlewareTest.php
@@ -27,11 +27,8 @@ class LastModifiedMiddlewareTest extends TestCase
     /** @var callable */
     private $next;
 
-    /**
-     * @var Request|MockObject
-     * @psalm-var MockObject&Request
-     */
-    private $request;
+    /** @psalm-var MockObject&Request */
+    private Request|MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php
+++ b/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php
@@ -19,11 +19,8 @@ class MethodNotAllowedMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /**
-     * @var Request|MockObject
-     * @psalm-var MockObject&Request
-     */
-    private $request;
+    /** @psalm-var MockObject&Request */
+    private Request|MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php
+++ b/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php
@@ -62,9 +62,10 @@ class MethodNotAllowedMiddlewareTest extends TestCase
             'request_method' => $method,
         ];
         $response              = new StaticResourceResponse();
-        $next                  = static fn(Request $request, string $filename): StaticResourceResponse => $response;
+        $next                  = static fn (Request $request, string $filename): StaticResourceResponse => $response;
         $middleware            = new MethodNotAllowedMiddleware();
 
+        /** @psalm-suppress InvalidArgument */
         $test = $middleware($this->request, '/does/not/matter', $next);
 
         $this->assertSame($response, $test);
@@ -84,6 +85,7 @@ class MethodNotAllowedMiddlewareTest extends TestCase
         };
         $middleware            = new MethodNotAllowedMiddleware();
 
+        /** @psalm-suppress InvalidArgument */
         $response = $middleware($this->request, '/does/not/matter', $next);
 
         $this->assertStatus(405, $response);

--- a/test/StaticResourceHandler/MiddlewareQueueTest.php
+++ b/test/StaticResourceHandler/MiddlewareQueueTest.php
@@ -20,11 +20,8 @@ class MiddlewareQueueTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /**
-     * @var Request|MockObject
-     * @psalm-var MockObject&Request
-     */
-    private $request;
+    /** @psalm-var MockObject&Request */
+    private Request|MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/OptionsMiddlewareTest.php
+++ b/test/StaticResourceHandler/OptionsMiddlewareTest.php
@@ -19,11 +19,8 @@ class OptionsMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /**
-     * @var Request|MockObject
-     * @psalm-var MockObject&Request
-     */
-    private $request;
+    /** @psalm-var MockObject&Request */
+    private Request|MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/OptionsMiddlewareTest.php
+++ b/test/StaticResourceHandler/OptionsMiddlewareTest.php
@@ -13,18 +13,18 @@ use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
 use MezzioTest\Swoole\AssertResponseTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Swoole\Http\Request;
+use Swoole\Http\Request as SwooleHttpRequest;
 
 class OptionsMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /** @psalm-var MockObject&Request */
-    private Request|MockObject $request;
+    /** @var MockObject&SwooleHttpRequest */
+    private MockObject $request;
 
     protected function setUp(): void
     {
-        $this->request = $this->createMock(Request::class);
+        $this->request = $this->createMock(SwooleHttpRequest::class);
     }
 
     /**
@@ -45,8 +45,8 @@ class OptionsMiddlewareTest extends TestCase
     public function testMiddlewareDoesNothingForNonOptionsRequests(string $method): void
     {
         $this->request->server = ['request_method' => $method];
-        $next                  = static fn(Request $request, string $filename): StaticResourceResponse
-            => new StaticResourceResponse();
+        $next                  = static fn (SwooleHttpRequest $request, string $filename): StaticResourceResponse
+        => new StaticResourceResponse();
 
         $middleware = new OptionsMiddleware();
 
@@ -60,8 +60,7 @@ class OptionsMiddlewareTest extends TestCase
     public function testMiddlewareSetsAllowHeaderAndDisablesContentForOptionsRequests(): void
     {
         $this->request->server = ['request_method' => 'OPTIONS'];
-        $next                  = static fn(Request $request, string $filename): StaticResourceResponse
-            => new StaticResourceResponse();
+        $next                  = static fn (SwooleHttpRequest $request, string $filename): StaticResourceResponse => new StaticResourceResponse();
 
         $middleware = new OptionsMiddleware();
 

--- a/test/StaticResourceHandler/StaticResourceResponseTest.php
+++ b/test/StaticResourceHandler/StaticResourceResponseTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace MezzioTest\Swoole\StaticResourceHandler;
 
 use Mezzio\Swoole\StaticResourceHandler\StaticResourceResponse;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Swoole\Http\Response as SwooleResponse;
 
@@ -18,6 +19,7 @@ class StaticResourceResponseTest extends TestCase
     {
         $expectedFilename = '/image.png';
 
+        /** @var SwooleResponse&MockObject $swooleResponse*/
         $swooleResponse = $this->createMock(SwooleResponse::class);
         $swooleResponse->expects($this->once())->method('status')->with(302);
         $swooleResponse
@@ -45,6 +47,7 @@ class StaticResourceResponseTest extends TestCase
     {
         $filename = '/image.png';
 
+        /** @var SwooleResponse&MockObject $swooleResponse*/
         $swooleResponse = $this->createMock(SwooleResponse::class);
         $swooleResponse->expects($this->once())->method('status')->with(302);
         $swooleResponse

--- a/test/SwooleStreamTest.php
+++ b/test/SwooleStreamTest.php
@@ -40,7 +40,6 @@ class SwooleStreamTest extends TestCase
             $this->markTestSkipped('The Swoole extension is not available');
         }
 
-        /** @var SwooleHttpRequest&MockObject */
         $this->request = $this->createMock(SwooleHttpRequest::class);
         $this->request
             ->method('rawContent')

--- a/test/SwooleStreamTest.php
+++ b/test/SwooleStreamTest.php
@@ -29,8 +29,8 @@ class SwooleStreamTest extends TestCase
      */
     public const DEFAULT_CONTENT = 'This is a test!';
 
-    /** @psalm-var SwooleHttpRequest&MockObject */
-    private SwooleHttpRequest|MockObject $request;
+    /** @var SwooleHttpRequest&MockObject */
+    private MockObject $request;
 
     private SwooleStream $stream;
 
@@ -40,6 +40,7 @@ class SwooleStreamTest extends TestCase
             $this->markTestSkipped('The Swoole extension is not available');
         }
 
+        /** @var SwooleHttpRequest&MockObject */
         $this->request = $this->createMock(SwooleHttpRequest::class);
         $this->request
             ->method('rawContent')

--- a/test/SwooleStreamTest.php
+++ b/test/SwooleStreamTest.php
@@ -24,13 +24,13 @@ use const SEEK_END;
 
 class SwooleStreamTest extends TestCase
 {
+    /**
+     * @var string
+     */
     public const DEFAULT_CONTENT = 'This is a test!';
 
-    /**
-     * @var SwooleHttpRequest|MockObject
-     * @psalm-var SwooleHttpRequest&MockObject
-     */
-    private $request;
+    /** @psalm-var SwooleHttpRequest&MockObject */
+    private SwooleHttpRequest|MockObject $request;
 
     private SwooleStream $stream;
 
@@ -131,7 +131,7 @@ class SwooleStreamTest extends TestCase
 
     public function testTellIndicatesIndexInString(): void
     {
-        for ($i = 0; $i < strlen(self::DEFAULT_CONTENT); $i++) {
+        for ($i = 0; $i < strlen(self::DEFAULT_CONTENT); ++$i) {
             $this->stream->seek($i);
             $this->assertEquals($i, $this->stream->tell());
         }

--- a/test/Task/DeferredListenerTest.php
+++ b/test/Task/DeferredListenerTest.php
@@ -19,6 +19,7 @@ use Webmozart\Assert\Assert;
 use function array_shift;
 use function count;
 use function is_array;
+use function is_countable;
 
 class DeferredListenerTest extends TestCase
 {
@@ -36,14 +37,18 @@ class DeferredListenerTest extends TestCase
             ->with($this->callback(static function (Task $task) use ($listener, $event): bool {
                 $r = new ReflectionProperty($task, 'handler');
                 $r->setAccessible(true);
+
                 $handler = $r->getValue($task);
                 Assert::object($handler);
 
                 $r = new ReflectionProperty($task, 'payload');
                 $r->setAccessible(true);
-                $payload = $r->getValue($task);
 
-                if (! is_array($payload) || 0 === count($payload)) {
+                $payload = $r->getValue($task);
+                if (! is_array($payload)) {
+                    return false;
+                }
+                if (0 === (is_countable($payload) ? count($payload) : 0)) {
                     return false;
                 }
 

--- a/test/Task/DeferredListenerTest.php
+++ b/test/Task/DeferredListenerTest.php
@@ -19,7 +19,6 @@ use Webmozart\Assert\Assert;
 use function array_shift;
 use function count;
 use function is_array;
-use function is_countable;
 
 class DeferredListenerTest extends TestCase
 {
@@ -48,7 +47,8 @@ class DeferredListenerTest extends TestCase
                 if (! is_array($payload)) {
                     return false;
                 }
-                if (0 === (is_countable($payload) ? count($payload) : 0)) {
+
+                if (0 === count($payload)) {
                     return false;
                 }
 

--- a/test/Task/DeferredServiceListenerTest.php
+++ b/test/Task/DeferredServiceListenerTest.php
@@ -20,6 +20,7 @@ use Webmozart\Assert\Assert;
 use function array_shift;
 use function count;
 use function is_array;
+use function is_countable;
 
 class DeferredServiceListenerTest extends TestCase
 {
@@ -47,14 +48,18 @@ class DeferredServiceListenerTest extends TestCase
             ->with($this->callback(static function (ServiceBasedTask $task) use ($event): bool {
                 $r = new ReflectionProperty($task, 'serviceName');
                 $r->setAccessible(true);
+
                 $serviceName = $r->getValue($task);
                 Assert::stringNotEmpty($serviceName);
 
                 $r = new ReflectionProperty($task, 'payload');
                 $r->setAccessible(true);
-                $payload = $r->getValue($task);
 
-                if (! is_array($payload) || 1 !== count($payload)) {
+                $payload = $r->getValue($task);
+                if (! is_array($payload)) {
+                    return false;
+                }
+                if (1 !== (is_countable($payload) ? count($payload) : 0)) {
                     return false;
                 }
 

--- a/test/Task/DeferredServiceListenerTest.php
+++ b/test/Task/DeferredServiceListenerTest.php
@@ -20,7 +20,6 @@ use Webmozart\Assert\Assert;
 use function array_shift;
 use function count;
 use function is_array;
-use function is_countable;
 
 class DeferredServiceListenerTest extends TestCase
 {
@@ -59,7 +58,8 @@ class DeferredServiceListenerTest extends TestCase
                 if (! is_array($payload)) {
                     return false;
                 }
-                if (1 !== (is_countable($payload) ? count($payload) : 0)) {
+
+                if (1 !== count($payload)) {
                     return false;
                 }
 

--- a/test/Task/TaskEventDispatchListenerFactoryTest.php
+++ b/test/Task/TaskEventDispatchListenerFactoryTest.php
@@ -19,10 +19,7 @@ use ReflectionProperty;
 
 class TaskEventDispatchListenerFactoryTest extends TestCase
 {
-    /**
-     * @param mixed $expected
-     */
-    public function asssertPropertySame($expected, string $property, object $instance, string $message = ''): void
+    public function asssertPropertySame(mixed $expected, string $property, object $instance, string $message = ''): void
     {
         $r = new ReflectionProperty($instance, $property);
         $r->setAccessible(true);

--- a/test/Task/TaskEventDispatchListenerTest.php
+++ b/test/Task/TaskEventDispatchListenerTest.php
@@ -18,9 +18,8 @@ use RuntimeException;
 use stdClass;
 
 use function array_key_exists;
-use function get_class;
 use function is_string;
-use function strpos;
+use function str_contains;
 
 class TaskEventDispatchListenerTest extends TestCase
 {
@@ -42,7 +41,7 @@ class TaskEventDispatchListenerTest extends TestCase
      */
     private LoggerInterface $logger;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->logger     = $this->createMock(LoggerInterface::class);
@@ -114,16 +113,17 @@ class TaskEventDispatchListenerTest extends TestCase
             ->with(
                 $this->stringContains('Error processing task'),
                 $this->callback(static function (array $context) use ($taskId, $exception): bool {
-                    if (
-                        ! array_key_exists('taskId', $context)
-                        || ! array_key_exists('error', $context)
-                        || ! is_string($context['error'])
-                    ) {
+                    if (! array_key_exists('taskId', $context)) {
                         return false;
                     }
-
+                    if (! array_key_exists('error', $context)) {
+                        return false;
+                    }
+                    if (! is_string($context['error'])) {
+                        return false;
+                    }
                     return $taskId === $context['taskId']
-                        && false !== strpos($context['error'], get_class($exception));
+                        && str_contains($context['error'], $exception::class);
                 })
             );
 

--- a/test/Task/TaskInvokerListenerFactoryTest.php
+++ b/test/Task/TaskInvokerListenerFactoryTest.php
@@ -16,10 +16,7 @@ use ReflectionProperty;
 
 class TaskInvokerListenerFactoryTest extends TestCase
 {
-    /**
-     * @param mixed $expected
-     */
-    public function assertPropertySame($expected, string $property, object $instance, string $message = ''): void
+    public function assertPropertySame(mixed $expected, string $property, object $instance, string $message = ''): void
     {
         $r = new ReflectionProperty($instance, $property);
         $r->setAccessible(true);

--- a/test/Task/TaskInvokerListenerTest.php
+++ b/test/Task/TaskInvokerListenerTest.php
@@ -20,10 +20,9 @@ use RuntimeException;
 use stdClass;
 
 use function array_key_exists;
-use function get_class;
 use function is_string;
 use function json_encode;
-use function strpos;
+use function str_contains;
 
 class TaskInvokerListenerTest extends TestCase
 {
@@ -45,7 +44,7 @@ class TaskInvokerListenerTest extends TestCase
      */
     private LoggerInterface $logger;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = $this->createMock(ContainerInterface::class);
         $this->logger    = $this->createMock(LoggerInterface::class);
@@ -164,7 +163,7 @@ class TaskInvokerListenerTest extends TestCase
                         && $taskId === $context['taskId']
                         && array_key_exists('error', $context)
                         && is_string($context['error'])
-                        && false !== strpos($context['error'], get_class($exception))),
+                        && str_contains($context['error'], $exception::class)),
                 ]
             );
 

--- a/test/Task/TaskTest.php
+++ b/test/Task/TaskTest.php
@@ -32,11 +32,11 @@ class TaskTest extends TestCase
             $second,
             $third
         ): string {
-                TestCase::assertSame($first, $one);
-                TestCase::assertSame($second, $two);
-                TestCase::assertSame($third, $three);
+            TestCase::assertSame($first, $one);
+            TestCase::assertSame($second, $two);
+            TestCase::assertSame($third, $three);
 
-                return $expected;
+            return $expected;
         };
 
         $task = new Task($handler, $first, $second, $third);

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -2,12 +2,19 @@
 
 declare(strict_types=1);
 
+namespace MezzioTest\Swoole;
+
 use Mezzio\Swoole\Exception\ExtensionNotLoadedException;
 
-require __DIR__ . '/../vendor/autoload.php';
+use function extension_loaded;
 
-if (! extension_loaded('swoole') && ! extension_loaded('openswoole')) {
-    throw new ExtensionNotLoadedException(
-        'One of either the swoole or openswoole extensions must be loaded to use mezzio/mezzio-swoole'
-    );
+require __DIR__ . '/../vendor/autoload.php';
+if (extension_loaded('swoole')) {
+    return;
 }
+if (extension_loaded('openswoole')) {
+    return;
+}
+throw new ExtensionNotLoadedException(
+    'One of either the swoole or openswoole extensions must be loaded to use mezzio/mezzio-swoole'
+);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Update composer config `platform.php` to `8.0.99`
- Update composer `PHP` to `~8.0.0 || ~8.1.0 || ~8.2.0`
- Ignore PHP platform requirements via `.laminas-ci.json`
- Resolves #103 