### PR TITLE
Fix Swoole v5 compatibility in hot reloader. Fix unit tests

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,6 +1,5 @@
 {
     "extensions": [
-        "inotify",
-        "swoole"
+        "inotify"
     ]
 }

--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+JOB=$3
+PHP_VERSION=$(echo "${JOB}" | jq -r '.php')
+
+apt update
+apt install -y "php${PHP_VERSION}-swoole"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 This library provides support for [Swoole](https://github.com/swoole/swoole-src) or [Open Swoole](https://www.swoole.co.uk/) for [Mezzio](https://docs.mezzio.dev/) applications.
 This means you can execute your Mezzio application using Swoole directly from the command line.
 
-
 ## Installation
 
 Run the following to install this library:

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "filp/whoops": "^2.15.2",
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-servicemanager": "^3.20",
-        "phpunit/phpunit": "^10.2.2",
+        "phpunit/phpunit": "^10.5",
         "psalm/plugin-phpunit": "^0.18.4",
         "swoole/ide-helper": "^5.0.3",
         "vimeo/psalm": "^5.12"

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "phpunit/phpunit": "^10.5",
         "psalm/plugin-phpunit": "^0.18.4",
         "swoole/ide-helper": "^5.0.3",
-        "vimeo/psalm": "^5.12"
+        "vimeo/psalm": "^5.19"
     },
     "suggest": {
         "ext-inotify": "To use inotify based file watcher. Required for hot code reloading.",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1017fde656250c694cf5de5b76b05ee4",
+    "content-hash": "c3bf5b27506b6a8f85c15411fdf2a73a",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -1199,7 +1199,7 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -1246,7 +1246,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -1422,16 +1422,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
@@ -1446,7 +1446,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1484,7 +1484,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -1500,7 +1500,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -1752,16 +1752,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
                 "shasum": ""
             },
             "require": {
@@ -1770,7 +1770,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1815,7 +1815,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -1831,7 +1831,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3182,16 +3182,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.16.0",
+            "version": "v4.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
                 "shasum": ""
             },
             "require": {
@@ -3232,9 +3232,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
             },
-            "time": "2023-06-25T14:52:30+00:00"
+            "time": "2023-12-10T21:03:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3558,23 +3558,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.2",
+            "version": "10.1.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "db1497ec8dd382e82c962f7abbe0320e4882ee4e"
+                "reference": "78c3b7625965c2513ee96569a4dbb62601784145"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/db1497ec8dd382e82c962f7abbe0320e4882ee4e",
-                "reference": "db1497ec8dd382e82c962f7abbe0320e4882ee4e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/78c3b7625965c2513ee96569a4dbb62601784145",
+                "reference": "78c3b7625965c2513ee96569a4dbb62601784145",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1",
                 "phpunit/php-file-iterator": "^4.0",
                 "phpunit/php-text-template": "^3.0",
@@ -3624,7 +3624,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.11"
             },
             "funding": [
                 {
@@ -3632,20 +3632,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-22T09:04:27+00:00"
+            "time": "2023-12-21T15:38:30+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.0.2",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "5647d65443818959172645e7ed999217360654b6"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/5647d65443818959172645e7ed999217360654b6",
-                "reference": "5647d65443818959172645e7ed999217360654b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
@@ -3685,7 +3685,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.2"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -3693,7 +3693,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T09:13:23+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -3760,16 +3760,16 @@
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
@@ -3807,7 +3807,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -3815,7 +3816,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:46+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -3878,16 +3879,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.2.2",
+            "version": "10.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1ab521b24b88b88310c40c26c0cc4a94ba40ff95"
+                "reference": "ed21115d505b4b4f7dc7b5651464e19a2c7f7856"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1ab521b24b88b88310c40c26c0cc4a94ba40ff95",
-                "reference": "1ab521b24b88b88310c40c26c0cc4a94ba40ff95",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ed21115d505b4b4f7dc7b5651464e19a2c7f7856",
+                "reference": "ed21115d505b4b4f7dc7b5651464e19a2c7f7856",
                 "shasum": ""
             },
             "require": {
@@ -3901,7 +3902,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.1",
+                "phpunit/php-code-coverage": "^10.1.5",
                 "phpunit/php-file-iterator": "^4.0",
                 "phpunit/php-invoker": "^4.0",
                 "phpunit/php-text-template": "^3.0",
@@ -3911,8 +3912,8 @@
                 "sebastian/comparator": "^5.0",
                 "sebastian/diff": "^5.0",
                 "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.0",
-                "sebastian/global-state": "^6.0",
+                "sebastian/exporter": "^5.1",
+                "sebastian/global-state": "^6.0.1",
                 "sebastian/object-enumerator": "^5.0",
                 "sebastian/recursion-context": "^5.0",
                 "sebastian/type": "^4.0",
@@ -3927,7 +3928,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.2-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -3959,7 +3960,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.5"
             },
             "funding": [
                 {
@@ -3975,7 +3976,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-11T06:15:20+00:00"
+            "time": "2023-12-27T15:13:52+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4206,16 +4207,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
                 "shasum": ""
             },
             "require": {
@@ -4226,7 +4227,7 @@
                 "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.3"
             },
             "type": "library",
             "extra": {
@@ -4270,7 +4271,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
             },
             "funding": [
                 {
@@ -4278,24 +4280,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:16+00:00"
+            "time": "2023-08-14T13:18:12+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.0.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -4304,7 +4306,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -4327,7 +4329,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -4335,20 +4338,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:47+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.3",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
                 "shasum": ""
             },
             "require": {
@@ -4361,7 +4364,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -4394,7 +4397,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.0"
             },
             "funding": [
                 {
@@ -4402,7 +4405,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T07:48:21+00:00"
+            "time": "2023-12-22T10:55:06+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -4470,16 +4473,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.0.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
+                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
                 "shasum": ""
             },
             "require": {
@@ -4493,7 +4496,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -4535,7 +4538,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
             },
             "funding": [
                 {
@@ -4543,20 +4547,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:49+00:00"
+            "time": "2023-09-24T13:22:09+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
                 "shasum": ""
             },
             "require": {
@@ -4596,7 +4600,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
             },
             "funding": [
                 {
@@ -4604,24 +4609,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:38+00:00"
+            "time": "2023-07-19T07:19:23+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -4653,7 +4658,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -4661,7 +4667,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:02+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -5225,16 +5231,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -5263,7 +5269,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -5271,7 +5277,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         },
         {
             "name": "vimeo/psalm",
@@ -5447,5 +5453,5 @@
     "platform-overrides": {
         "php": "8.1.99"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3bf5b27506b6a8f85c15411fdf2a73a",
+    "content-hash": "1761d04d2bd4f19d5d46ea78ffeb5f53",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -5281,16 +5281,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.12.0",
+            "version": "5.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f90118cdeacd0088e7215e64c0c99ceca819e176"
+                "reference": "06b71be009a6bd6d81b9811855d6629b9fe90e1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f90118cdeacd0088e7215e64c0c99ceca819e176",
-                "reference": "f90118cdeacd0088e7215e64c0c99ceca819e176",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06b71be009a6bd6d81b9811855d6629b9fe90e1b",
+                "reference": "06b71be009a6bd6d81b9811855d6629b9fe90e1b",
                 "shasum": ""
             },
             "require": {
@@ -5309,14 +5309,17 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.14",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+                "nikic/php-parser": "^4.16",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
                 "sebastian/diff": "^4.0 || ^5.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
-                "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0"
+                "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
+            },
+            "conflict": {
+                "nikic/php-parser": "4.17.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
@@ -5335,7 +5338,7 @@
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
                 "squizlabs/php_codesniffer": "^3.6",
-                "symfony/process": "^4.4 || ^5.0 || ^6.0"
+                "symfony/process": "^4.4 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
                 "ext-curl": "In order to send data to shepherd",
@@ -5348,7 +5351,7 @@
                 "psalm-refactor",
                 "psalter"
             ],
-            "type": "library",
+            "type": "project",
             "extra": {
                 "branch-alias": {
                     "dev-master": "5.x-dev",
@@ -5380,10 +5383,11 @@
                 "static analysis"
             ],
             "support": {
+                "docs": "https://psalm.dev/docs",
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.12.0"
+                "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2023-05-22T21:19:03+00:00"
+            "time": "2024-01-09T21:02:43+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.12.0@f90118cdeacd0088e7215e64c0c99ceca819e176">
+<files psalm-version="5.19.0@06b71be009a6bd6d81b9811855d6629b9fe90e1b">
   <file src="src/AbstractStaticResourceHandlerFactory.php">
     <MixedArrayOffset>
       <code>$cacheControlDirectives[$regex]</code>
@@ -25,14 +25,6 @@
     <UnusedClass>
       <code>InvalidConfigException</code>
     </UnusedClass>
-  </file>
-  <file src="src/HotCodeReload/FileWatcher/InotifyFileWatcher.php">
-    <LessSpecificReturnStatement>
-      <code>$paths</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[list<non-empty-string>]]></code>
-    </MoreSpecificReturnType>
   </file>
   <file src="src/HttpServerFactory.php">
     <InvalidConstantAssignmentValue>
@@ -90,11 +82,17 @@
     </MixedPropertyTypeCoercion>
   </file>
   <file src="src/StaticResourceHandler/CacheControlMiddleware.php">
+    <ArgumentTypeCoercion>
+      <code>$regexp</code>
+    </ArgumentTypeCoercion>
     <MixedPropertyTypeCoercion>
       <code>$cacheControlDirectives</code>
     </MixedPropertyTypeCoercion>
   </file>
   <file src="src/StaticResourceHandler/ETagMiddleware.php">
+    <ArgumentTypeCoercion>
+      <code>$regexp</code>
+    </ArgumentTypeCoercion>
     <MixedPropertyTypeCoercion>
       <code>$etagDirectives</code>
     </MixedPropertyTypeCoercion>
@@ -117,6 +115,16 @@
     <UnusedFunctionCall>
       <code>stream_filter_append</code>
     </UnusedFunctionCall>
+  </file>
+  <file src="src/StaticResourceHandler/LastModifiedMiddleware.php">
+    <ArgumentTypeCoercion>
+      <code>$regexp</code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="src/StaticResourceHandler/ValidateRegexTrait.php">
+    <ArgumentTypeCoercion>
+      <code>$regex</code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="src/SwooleEmitter.php">
     <PossiblyNullReference>

--- a/src/Event/HotCodeReloaderWorkerStartListener.php
+++ b/src/Event/HotCodeReloaderWorkerStartListener.php
@@ -11,6 +11,7 @@ namespace Mezzio\Swoole\Event;
 use Mezzio\Swoole\HotCodeReload\FileWatcherInterface;
 use Psr\Log\LoggerInterface;
 use Swoole\Server;
+use Swoole\Timer;
 
 class HotCodeReloaderWorkerStartListener
 {
@@ -35,7 +36,7 @@ class HotCodeReloaderWorkerStartListener
         $fileWatcher = $this->fileWatcher;
         $logger      = $this->logger;
 
-        $server->tick($this->interval, static function () use ($server, $fileWatcher, $logger): void {
+        static::tick($this->interval, static function () use ($server, $fileWatcher, $logger): void {
             $changedFilePaths = $fileWatcher->readChangedFilePaths();
             if ($changedFilePaths === []) {
                 return;
@@ -47,5 +48,13 @@ class HotCodeReloaderWorkerStartListener
 
             $server->reload();
         });
+    }
+
+    /**
+     * @internal For unit testing static dependency only.
+     */
+    protected function tick(int $ms, callable $callback): void
+    {
+        Timer::tick($ms, $callback);
     }
 }

--- a/test/Command/StartCommandTest.php
+++ b/test/Command/StartCommandTest.php
@@ -216,11 +216,11 @@ class StartCommandTest extends TestCase
 
         $this->input
             ->method('getOption')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['daemonize', true],
                 ['num-workers', 6],
                 ['num-task-workers', 4],
-            ]));
+            ]);
 
         $this->pidManager->method('read')->willReturn($pids);
 
@@ -243,12 +243,12 @@ class StartCommandTest extends TestCase
 
         $this->container
             ->method('get')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [PidManager::class, $this->pidManager],
                 [SwooleHttpServer::class, $httpServer],
                 [MiddlewareFactory::class, $middlewareFactory],
                 [Application::class, $application],
-            ]));
+            ]);
 
         $command = new StartCommand($this->container);
 
@@ -264,11 +264,11 @@ class StartCommandTest extends TestCase
     {
         $this->input
             ->method('getOption')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['daemonize', false],
                 ['num-workers', null],
                 ['num-task-workers', null],
-            ]));
+            ]);
 
         [$command, $httpServer, $application] = $this->prepareSuccessfulStartCommand($pids);
 
@@ -303,12 +303,12 @@ class StartCommandTest extends TestCase
         $this->pidManager->method('read')->willReturn($pids);
         $this->container
             ->method('get')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [PidManager::class, $this->pidManager],
                 [SwooleHttpServer::class, $httpServer],
                 [MiddlewareFactory::class, $middlewareFactory],
                 [Application::class, $application],
-            ]));
+            ]);
 
         $command = new StartCommand($this->container);
 

--- a/test/Event/HotCodeReloaderWorkerStartListenerFactoryTest.php
+++ b/test/Event/HotCodeReloaderWorkerStartListenerFactoryTest.php
@@ -32,10 +32,10 @@ class HotCodeReloaderWorkerStartListenerFactoryTest extends TestCase
         $container
             ->expects($this->exactly(2))
             ->method('get')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [FileWatcherInterface::class, $fileWatcher],
                 [AccessLogInterface::class, $logger],
-            ]));
+            ]);
 
         $factory = new HotCodeReloaderWorkerStartListenerFactory();
         $this->assertIsObject($factory($container));
@@ -64,11 +64,11 @@ class HotCodeReloaderWorkerStartListenerFactoryTest extends TestCase
         $container
             ->expects($this->exactly(3))
             ->method('get')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 [FileWatcherInterface::class, $fileWatcher],
                 [AccessLogInterface::class, $logger],
                 ['config', $config],
-            ]));
+            ]);
 
         $fileWatcher
             ->expects($this->exactly(2))

--- a/test/Event/TestAsset/HotCodeReloaderWorkerStartListenerStub.php
+++ b/test/Event/TestAsset/HotCodeReloaderWorkerStartListenerStub.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole\Event\TestAsset;
+
+use Closure;
+use Mezzio\Swoole\Event\HotCodeReloaderWorkerStartListener;
+use Override;
+
+class HotCodeReloaderWorkerStartListenerStub extends HotCodeReloaderWorkerStartListener
+{
+    public Closure $callbackTickAssertion;
+    #[Override]
+    protected function tick(int $ms, callable $callback): void
+    {
+        ($this->callbackTickAssertion)($ms, $callback);
+    }
+}

--- a/test/HttpServerFactoryTest.php
+++ b/test/HttpServerFactoryTest.php
@@ -20,7 +20,6 @@ use Swoole\Http\Server as SwooleServer;
 use Swoole\Process;
 use Swoole\Runtime as SwooleRuntime;
 use Throwable;
-use Webmozart\Assert\Assert;
 
 use function array_merge;
 use function defined;
@@ -341,13 +340,11 @@ class HttpServerFactoryTest extends TestCase
 
         $i = 0;
         go(static function () use (&$i): void {
-            Assert::integer($i);
             usleep(1000);
             ++$i;
             SwooleEvent::exit();
         });
         go(function () use (&$i): void {
-            Assert::integer($i);
             ++$i;
             $this->assertEquals(1, $i);
         });

--- a/test/Log/LoggerFactoryHelperTrait.php
+++ b/test/Log/LoggerFactoryHelperTrait.php
@@ -112,7 +112,7 @@ trait LoggerFactoryHelperTrait
                 $valueMap[] = [$service, $value];
             }
 
-            $container->method($method)->will($this->returnValueMap($valueMap));
+            $container->method($method)->willReturnMap($valueMap);
         }
 
         return $container;

--- a/test/StaticMappedResourceHandlerFactoryTest.php
+++ b/test/StaticMappedResourceHandlerFactoryTest.php
@@ -111,10 +111,10 @@ class StaticMappedResourceHandlerFactoryTest extends TestCase
 
         $this->container
             ->method('get')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['config', $config],
                 [FileLocationRepositoryInterface::class, $this->fileLocRepo],
-            ]));
+            ]);
 
         $factory = new StaticMappedResourceHandlerFactory();
 

--- a/test/StaticResourceHandler/GzipMiddlewareTest.php
+++ b/test/StaticResourceHandler/GzipMiddlewareTest.php
@@ -161,7 +161,6 @@ class GzipMiddlewareTest extends TestCase
                 string|array $value,
                 bool $format = true
             ) use (&$actualHeaderCalls): bool {
-                /** @psalm-var array $actualHeaderCalls */
                 $actualHeaderCalls[] = [$key, $value, $format];
                 return true;
             });

--- a/test/StaticResourceHandler/IntegrationMappedTest.php
+++ b/test/StaticResourceHandler/IntegrationMappedTest.php
@@ -80,10 +80,10 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'image/png', true],
                 ['Allow', 'GET, HEAD, OPTIONS', true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(405);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile');
@@ -115,10 +115,10 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'image/png', true],
                 ['Allow', 'GET, HEAD, OPTIONS', true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile');
@@ -157,13 +157,13 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(5))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
-                ['Content-Length', $this->anything(), true],
+                ['Content-Length', '9', true],
                 ['Cache-Control', 'public, no-transform', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->never())->method('end');
         $response->expects($this->once())->method('sendfile')->with($file);
@@ -209,12 +209,12 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(4))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['Cache-Control', 'public, no-transform', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -263,13 +263,13 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(5))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['Allow', 'GET, HEAD, OPTIONS', true],
                 ['Cache-Control', 'public, no-transform', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -321,11 +321,11 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(3))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
-                ['Content-Length', $this->anything(), true],
+                ['Content-Length', '9', true],
                 ['Cache-Control', 'public, no-transform', true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->never())->method('end');
         $response->expects($this->once())->method('sendfile')->with($file);
@@ -374,10 +374,10 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['Cache-Control', 'public, no-transform', true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -424,10 +424,10 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(304);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -475,10 +475,10 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(304);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -523,11 +523,11 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(3))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
-                ['Content-Length', $this->anything(), true],
+                ['Content-Length', '9', true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->never())->method('end');
         $response->expects($this->once())->method('sendfile')->with($file);
@@ -575,10 +575,10 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
-                ['Content-Type', 'image/png', true],
+            ->willReturnMap([
+                ['Content-Type', 'text/plain', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(304);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -625,11 +625,11 @@ class IntegrationMappedTest extends TestCase
         $response
             ->expects($this->exactly(3))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
-                ['Content-Length', $this->anything(), true],
+                ['Content-Length', '9', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->never())->method('end');
         $response->expects($this->once())->method('sendfile')->with($file);

--- a/test/StaticResourceHandler/IntegrationTest.php
+++ b/test/StaticResourceHandler/IntegrationTest.php
@@ -70,10 +70,10 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'image/png', true],
                 ['Allow', 'GET, HEAD, OPTIONS', true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(405);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile');
@@ -101,10 +101,10 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'image/png', true],
                 ['Allow', 'GET, HEAD, OPTIONS', true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile');
@@ -138,13 +138,13 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(5))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
-                ['Content-Length', $this->anything(), true],
+                ['Content-Length', '9', true],
                 ['Cache-Control', 'public, no-transform', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->never())->method('end');
         $response->expects($this->once())->method('sendfile')->with($file);
@@ -185,12 +185,12 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(4))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['Cache-Control', 'public, no-transform', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -234,13 +234,13 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(5))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['Allow', 'GET, HEAD, OPTIONS', true],
                 ['Cache-Control', 'public, no-transform', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -287,11 +287,11 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(3))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
-                ['Content-Length', $this->anything(), true],
+                ['Content-Length', '9', true],
                 ['Cache-Control', 'public, no-transform', true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->never())->method('end');
         $response->expects($this->once())->method('sendfile')->with($file);
@@ -335,10 +335,10 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['Cache-Control', 'public, no-transform', true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -380,10 +380,10 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(304);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -426,10 +426,10 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(304);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -469,11 +469,11 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(3))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
-                ['Content-Length', $this->anything(), true],
+                ['Content-Length', '9', true],
                 ['ETag', $etag, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->never())->method('end');
         $response->expects($this->once())->method('sendfile')->with($file);
@@ -516,10 +516,10 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(2))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(304);
         $response->expects($this->once())->method('end');
         $response->expects($this->never())->method('sendfile')->with($file);
@@ -561,11 +561,11 @@ class IntegrationTest extends TestCase
         $response
             ->expects($this->exactly(3))
             ->method('header')
-            ->will($this->returnValueMap([
+            ->willReturnMap([
                 ['Content-Type', 'text/plain', true],
-                ['Content-Length', $this->anything(), true],
+                ['Content-Length', '9', true],
                 ['Last-Modified', $lastModifiedFormatted, true],
-            ]));
+            ]);
         $response->expects($this->once())->method('status')->with(200);
         $response->expects($this->never())->method('end');
         $response->expects($this->once())->method('sendfile')->with($file);

--- a/test/StaticResourceHandler/MiddlewareQueueTest.php
+++ b/test/StaticResourceHandler/MiddlewareQueueTest.php
@@ -66,7 +66,7 @@ class MiddlewareQueueTest extends TestCase
         $first
             ->method('__invoke')
             ->with($this->request, 'some/filename.txt', $this->isInstanceOf(MiddlewareQueue::class))
-            ->will($this->returnCallback(
+            ->willReturnCallback(
                 function (
                     Request $request,
                     string $filename,
@@ -75,7 +75,7 @@ class MiddlewareQueueTest extends TestCase
                     $second
                         ->method('__invoke')
                         ->with($request, $filename, $middlewareQueue)
-                        ->will($this->returnCallback(
+                        ->willReturnCallback(
                             static function (
                                 Request $request,
                                 string $filename,
@@ -87,11 +87,11 @@ class MiddlewareQueueTest extends TestCase
                                 $response->disableContent();
                                 return $response;
                             }
-                        ));
+                        );
 
                     return $middlewareQueue($request, $filename);
                 }
-            ));
+            );
 
         /** @psalm-suppress InternalClass,InternalMethod */
         $queue = new MiddlewareQueue([$first, $second]);

--- a/test/StaticResourceHandler/StaticResourceResponseTest.php
+++ b/test/StaticResourceHandler/StaticResourceResponseTest.php
@@ -35,7 +35,6 @@ class StaticResourceResponseTest extends TestCase
                 string|array $value,
                 bool $format = true
             ) use (&$actualHeaderCalls): bool {
-                /** @psalm-var array $actualHeaderCalls */
                 $actualHeaderCalls[] = [$key, $value, $format];
                 return true;
             });
@@ -78,7 +77,6 @@ class StaticResourceResponseTest extends TestCase
                 string|array $value,
                 bool $format = true
             ) use (&$actualHeaderCalls): bool {
-                /** @psalm-var array $actualHeaderCalls */
                 $actualHeaderCalls[] = [$key, $value, $format];
                 return true;
             });

--- a/test/SwooleEmitterTest.php
+++ b/test/SwooleEmitterTest.php
@@ -86,7 +86,6 @@ class SwooleEmitterTest extends TestCase
                 string $key,
                 string|array $value
             ) use (&$actualHeaderCalls): bool {
-                /** @psalm-var array $actualHeaderCalls */
                 $actualHeaderCalls[] = [$key, $value];
                 return true;
             });
@@ -152,7 +151,6 @@ class SwooleEmitterTest extends TestCase
                 bool $httponly = false,
                 string $samesite = ''
             ) use (&$actualCookieCalls): bool {
-                /** @psalm-var array $actualCookieCalls */
                 $actualCookieCalls[] = [$name, $value, $expires, $path, $domain, $secure, $httponly, $samesite];
                 return true;
             });

--- a/test/SwooleRequestHandlerRunnerTest.php
+++ b/test/SwooleRequestHandlerRunnerTest.php
@@ -82,24 +82,24 @@ class SwooleRequestHandlerRunnerTest extends TestCase
         $this->httpServer
             ->expects($this->exactly(10))
             ->method('on')
-            ->will($this->returnValueMap([
-                ['managerstart', [$this->runner, 'onManagerStart'], null],
-                ['managerstop', [$this->runner, 'onManagerStop'], null],
-                ['workerstart', [$this->runner, 'onWorkerStart'], null],
-                ['workerstop', [$this->runner, 'onWorkerStop'], null],
-                ['workererror', [$this->runner, 'onWorkerError'], null],
-                ['request', [$this->runner, 'onRequest'], null],
-                ['beforereload', [$this->runner, 'onBeforeReload'], null],
-                ['afterreload', [$this->runner, 'onAfterReload'], null],
-                ['task', [$this->runner, 'onTask'], null],
-                ['finish', [$this->runner, 'onTaskFinish'], null],
-            ]));
+            ->willReturnMap([
+                ['managerstart', [$this->runner, 'onManagerStart'], true],
+                ['managerstop', [$this->runner, 'onManagerStop'], true],
+                ['workerstart', [$this->runner, 'onWorkerStart'], true],
+                ['workerstop', [$this->runner, 'onWorkerStop'], true],
+                ['workererror', [$this->runner, 'onWorkerError'], true],
+                ['request', [$this->runner, 'onRequest'], true],
+                ['beforereload', [$this->runner, 'onBeforeReload'], true],
+                ['afterreload', [$this->runner, 'onAfterReload'], true],
+                ['task', [$this->runner, 'onTask'], true],
+                ['finish', [$this->runner, 'onTaskFinish'], true],
+            ]);
 
         $this->httpServer
             ->expects($this->once())
             ->method('start');
 
-        $this->assertNull($this->runner->run());
+        $this->runner->run();
     }
 
     public function testRunRegistersExpectedHttpServerListenersAndStartsServerWhenInProcessMode(): void
@@ -108,26 +108,26 @@ class SwooleRequestHandlerRunnerTest extends TestCase
         $this->httpServer
             ->expects($this->exactly(12))
             ->method('on')
-            ->will($this->returnValueMap([
-                ['start', [$this->runner, 'onStart'], null],
-                ['shutdown', [$this->runner, 'onShutdown'], null],
-                ['managerstart', [$this->runner, 'onManagerStart'], null],
-                ['managerstop', [$this->runner, 'onManagerStop'], null],
-                ['workerstart', [$this->runner, 'onWorkerStart'], null],
-                ['workerstop', [$this->runner, 'onWorkerStop'], null],
-                ['workererror', [$this->runner, 'onWorkerError'], null],
-                ['request', [$this->runner, 'onRequest'], null],
-                ['beforereload', [$this->runner, 'onBeforeReload'], null],
-                ['afterreload', [$this->runner, 'onAfterReload'], null],
-                ['task', [$this->runner, 'onTask'], null],
-                ['finish', [$this->runner, 'onTaskFinish'], null],
-            ]));
+            ->willReturnMap([
+                ['start', [$this->runner, 'onStart'], true],
+                ['shutdown', [$this->runner, 'onShutdown'], true],
+                ['managerstart', [$this->runner, 'onManagerStart'], true],
+                ['managerstop', [$this->runner, 'onManagerStop'], true],
+                ['workerstart', [$this->runner, 'onWorkerStart'], true],
+                ['workerstop', [$this->runner, 'onWorkerStop'], true],
+                ['workererror', [$this->runner, 'onWorkerError'], true],
+                ['request', [$this->runner, 'onRequest'], true],
+                ['beforereload', [$this->runner, 'onBeforeReload'], true],
+                ['afterreload', [$this->runner, 'onAfterReload'], true],
+                ['task', [$this->runner, 'onTask'], true],
+                ['finish', [$this->runner, 'onTaskFinish'], true],
+            ]);
 
         $this->httpServer
             ->expects($this->once())
             ->method('start');
 
-        $this->assertNull($this->runner->run());
+        $this->runner->run();
     }
 
     public function testOnStartDispatchesServerStartEvent(): void
@@ -274,7 +274,7 @@ class SwooleRequestHandlerRunnerTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $this->runner->onTask($this->httpServer, 1, 10, ['values', 'to', 'process']);
     }
@@ -309,7 +309,7 @@ class SwooleRequestHandlerRunnerTest extends TestCase
 
                 return true;
             }))
-            ->will($this->returnArgument(0));
+            ->willReturnArgument(0);
 
         $task = new class ($server) {
             public int $id = 1;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

Changing CI setup to use swoole from ondrej ppa used in our CI container. This is not ideal setup but it will allow to unblock support for PHP 8.3.

Current CI setup is not sufficient as it does not test different versions of swoole and does not test for openswoole. It is a task for another day. Considering swoole and openswoole are set to diverge different kind of approach would need to be taken anyway.

Stricter types in swoole v5 uncovered some deficiencies in unit test mocks. This PR fixes those issues and takes care of updating a few phpunit deprecations. 

While rest of the mezzio-swoole is compatible with v5, hot reloader functionality was not due to removal of decorator method `Swoole\Server::tick()`. Hot reloader listener is updated to use `Swoole\Timer::tick()` directly.