### PR TITLE
Prepare for working with newer versions of OpenSwoole.

### DIFF
--- a/compat/openswoole.php
+++ b/compat/openswoole.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenSwoole\Util;
+
+// @see https://github.com/mezzio/mezzio-swoole/issues/110#issuecomment-1500174967
+// Override the swoole_set_process_name function
+if (version_compare(phpversion('openswoole'), '22.0.0', '>=')) {
+    function swoole_set_process_name(string $process_name): void
+    {
+        Util::setProcessName($process_name);
+    }
+}

--- a/compat/openswoole.php
+++ b/compat/openswoole.php
@@ -6,7 +6,7 @@ use OpenSwoole\Util;
 
 // @see https://github.com/mezzio/mezzio-swoole/issues/110#issuecomment-1500174967
 // Override the swoole_set_process_name function
-if (version_compare(phpversion('openswoole'), '22.0.0', '>=')) {
+if (version_compare((string)phpversion('openswoole'), '22.0.0', '>=')) {
     function swoole_set_process_name(string $process_name): void
     {
         Util::setProcessName($process_name);

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,10 @@
     "autoload": {
         "psr-4": {
             "Mezzio\\Swoole\\": "src/"
-        }
+        },
+        "files": [
+            "compat/openswoole.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/docs/book/v4/migration.md
+++ b/docs/book/v4/migration.md
@@ -43,3 +43,10 @@ return [
 ```
 
 If you are using Mezzio 3.11.0 or later, you can also use its `Mezzio\Container\FilterUsingXForwardedHeadersFactory` and related configuration to fine-tune which sources may be considered for usage of these headers.
+
+## Support for OpenSwoole 22.0.x
+
+INFO: Since 4.10.0 mezzio-swoole supports the use of openswoole PHP extension version 22.0 and later.
+
+If your application has custom code that re-implements the function `swoole_set_process_name` then make sure to remove it.
+This package will take care of the compatibility issues.


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Make Mezzio Compatible with OpenSwoole v 22.0 and newer

This PR adds initial compatibility with OpenSwoole v22.0 and newer.
The changes in the PR are inspired by @Xerkus   [work](https://github.com/laminas/laminas.dev/pull/45) and all credit goes to him. 
This PR is related to #110.

### TODO
- [x] Update the [migration document](https://github.com/mezzio/mezzio-swoole/blob/4.10.x/docs/book/v4/migration.md) and mention that custom fixes are no longer needed to support openswoole >= v22.0