### PR TITLE
Updated dependency symfony/console to ^5.3 || ^6.0.19 || ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
             "composer/package-versions-deprecated": true
         },
         "platform": {
-            "php": "8.1.99"
+            "php": "8.2.99"
         }
     },
     "extra": {
     },
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.2.0 || ~8.3.0",
         "dflydev/fig-cookies": "^2.0.1 || ^3.0",
         "laminas/laminas-cli": "^1.8",
         "laminas/laminas-diactoros": "^2.25.2 || ^3.0",
@@ -47,7 +47,7 @@
         "psr/http-message-implementation": "^1.0 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^5.0 || ^6.0.19",
+        "symfony/console": "^5.0 || ^6.0.19 || ^7.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "psr/http-message-implementation": "^1.0 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^5.0 || ^6.0.19 || ^7.0",
+        "symfony/console": "^5.3 || ^6.0.19 || ^7.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1761d04d2bd4f19d5d46ea78ffeb5f53",
+    "content-hash": "1152a47b1909953f72cae4ad39b97f2f",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -1109,47 +1109,46 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.2",
+            "version": "v7.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "0254811a143e6bc6c8deea08b589a7e68a37f625"
+                "reference": "1eed7af6961d763e7832e874d7f9b21c3ea9c111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/0254811a143e6bc6c8deea08b589a7e68a37f625",
-                "reference": "0254811a143e6bc6c8deea08b589a7e68a37f625",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1eed7af6961d763e7832e874d7f9b21c3ea9c111",
+                "reference": "1eed7af6961d763e7832e874d7f9b21c3ea9c111",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.2",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/string": "^6.4|^7.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
                 "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -1183,7 +1182,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.2"
+                "source": "https://github.com/symfony/console/tree/v7.1.4"
             },
             "funding": [
                 {
@@ -1199,74 +1198,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-10T16:15:48+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2024-08-15T22:48:53+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -5476,11 +5408,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0"
+        "php": "~8.2.0 || ~8.3.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.1.99"
+        "php": "8.2.99"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1152a47b1909953f72cae4ad39b97f2f",
+    "content-hash": "7889e27593f51ecf32844e51c3c17e59",
     "packages": [
         {
             "name": "dflydev/fig-cookies",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -5,6 +5,26 @@
       <code>$cacheControlDirectives[$regex]</code>
     </MixedArrayOffset>
   </file>
+  <file src="src/Command/ReloadCommand.php">
+    <PossiblyUnusedProperty>
+      <code>$defaultName</code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/Command/StartCommand.php">
+    <PossiblyUnusedProperty>
+      <code>$defaultName</code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/Command/StatusCommand.php">
+    <PossiblyUnusedProperty>
+      <code>$defaultName</code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/Command/StopCommand.php">
+    <PossiblyUnusedProperty>
+      <code>$defaultName</code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="src/Event/ServerShutdownEvent.php">
     <PossiblyUnusedMethod>
       <code>getServer</code>

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -35,6 +35,13 @@ This command is only relevant when the server was started using the
 configuration value is set to SWOOLE_PROCESS.
 EOH;
 
+    /**
+     * @deprecated Use ReloadCommand::getDefaultName() instead. Will be removed in 5.0.0
+     *
+     * @var null|string
+     */
+    public static $defaultName = 'mezzio:swoole:reload';
+
     public function __construct(private int $serverMode)
     {
         parent::__construct();

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Mezzio\Swoole\Command;
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,6 +20,7 @@ use function sleep;
 
 use const SWOOLE_PROCESS;
 
+#[AsCommand('mezzio:swoole:reload')]
 class ReloadCommand extends Command
 {
     /**
@@ -32,9 +34,6 @@ This command is only relevant when the server was started using the
 --daemonize option, and the mezzio-swoole.swoole-http-server.mode
 configuration value is set to SWOOLE_PROCESS.
 EOH;
-
-    /** @var null|string Cannot be defined explicitly due to parent class */
-    public static $defaultName = 'mezzio:swoole:reload';
 
     public function __construct(private int $serverMode)
     {
@@ -73,7 +72,7 @@ EOH;
         /** @var Application $application */
         $application = $this->getApplication();
 
-        $stop   = $application->find(StopCommand::$defaultName);
+        $stop   = $application->find(StopCommand::getDefaultName());
         $result = $stop->run(new ArrayInput([
             'command' => 'stop',
         ]), $output);
@@ -92,7 +91,7 @@ EOH;
         $output->writeln('<info>[DONE]</info>');
         $output->writeln('<info>Starting server</info>');
 
-        $start = $application->find(StartCommand::$defaultName);
+        $start = $application->find(StartCommand::getDefaultName());
 
         $inputArguments = [
             'command'       => 'start',

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -53,6 +53,13 @@ EOH;
         'config/routes.php',
     ];
 
+    /**
+     * @deprecated Use StartCommand::getDefaultName() instead. Will be removed in 5.0.0
+     *
+     * @var null|string
+     */
+    public static $defaultName = 'mezzio:swoole:start';
+
     public function __construct(private ContainerInterface $container)
     {
         parent::__construct();

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -13,6 +13,7 @@ use Mezzio\MiddlewareFactory;
 use Mezzio\Swoole\PidManager;
 use Psr\Container\ContainerInterface;
 use Swoole\Http\Server as SwooleHttpServer;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -20,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function file_exists;
 
+#[AsCommand('mezzio:swoole:start')]
 class StartCommand extends Command
 {
     use IsRunningTrait;
@@ -50,9 +52,6 @@ EOH;
         'config/pipeline.php',
         'config/routes.php',
     ];
-
-    /** @var null|string Cannot be defined explicitly due to parent class */
-    public static $defaultName = 'mezzio:swoole:start';
 
     public function __construct(private ContainerInterface $container)
     {

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 namespace Mezzio\Swoole\Command;
 
 use Mezzio\Swoole\PidManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand('mezzio:swoole:status')]
 class StatusCommand extends Command
 {
     use IsRunningTrait;
@@ -26,9 +28,6 @@ Find out if the server is running.
 This command is only relevant when the server was started using the
 --daemonize option.
 EOH;
-
-    /** @var null|string Cannot be defined explicitly due to parent class */
-    public static $defaultName = 'mezzio:swoole:status';
 
     public function __construct(private PidManager $pidManager)
     {

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -29,6 +29,13 @@ This command is only relevant when the server was started using the
 --daemonize option.
 EOH;
 
+    /**
+     * @deprecated Use StatusCommand::getDefaultName() instead. Will be removed in 5.0.0
+     *
+     * @var null|string
+     */
+    public static $defaultName = 'mezzio:swoole:status';
+
     public function __construct(private PidManager $pidManager)
     {
         parent::__construct();

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -11,6 +11,7 @@ namespace Mezzio\Swoole\Command;
 use Closure;
 use Mezzio\Swoole\PidManager;
 use Swoole\Process as SwooleProcess;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function time;
 use function usleep;
 
+#[AsCommand('mezzio:swoole:stop')]
 class StopCommand extends Command
 {
     use IsRunningTrait;
@@ -31,9 +33,6 @@ Stop the web server. Kills all worker processes and stops the web server.
 This command is only relevant when the server was started using the
 --daemonize option.
 EOH;
-
-    /** @var null|string Cannot be defined explicitly due to parent class */
-    public static $defaultName = 'mezzio:swoole:stop';
 
     /**
      * @internal

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -35,6 +35,13 @@ This command is only relevant when the server was started using the
 EOH;
 
     /**
+     * @deprecated Use StopCommand::getDefaultName() instead. Will be removed in 5.0.0
+     *
+     * @var null|string
+     */
+    public static $defaultName = 'mezzio:swoole:stop';
+
+    /**
      * @internal
      *
      * @var Closure Callable to execute when attempting to kill the server

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -149,7 +149,7 @@ class ReloadCommandTest extends TestCase
             ->willReturn(1);
 
         $application = $this->mockApplication();
-        $application->method('find')->with(StopCommand::$defaultName)->willReturn($stopCommand);
+        $application->method('find')->with(StopCommand::getDefaultName())->willReturn($stopCommand);
 
         $command->setApplication($application);
 
@@ -200,8 +200,8 @@ class ReloadCommandTest extends TestCase
             ->expects($this->exactly(2))
             ->method('find')
             ->willReturnMap([
-                [StopCommand::$defaultName, $stopCommand],
-                [StartCommand::$defaultName, $startCommand],
+                [StopCommand::getDefaultName(), $stopCommand],
+                [StartCommand::getDefaultName(), $startCommand],
             ]);
 
         $command->setApplication($application);
@@ -270,8 +270,8 @@ class ReloadCommandTest extends TestCase
             ->expects($this->exactly(2))
             ->method('find')
             ->willReturnMap([
-                [StopCommand::$defaultName, $stopCommand],
-                [StartCommand::$defaultName, $startCommand],
+                [StopCommand::getDefaultName(), $stopCommand],
+                [StartCommand::getDefaultName(), $startCommand],
             ]);
 
         $this->output


### PR DESCRIPTION
Allow symfony/console ^7.0. 

`Command::$defaultName` has been replaced with `#[AsCommand()]` in 7.0. This was first introduced in 5.3 which is why the minimum version was raised.

This also requires dropping support for php 8.1.