### PR TITLE
Add PHP 8.4 to composer

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,5 +1,8 @@
 {
     "extensions": [
         "inotify"
-    ]
+    ],
+    "ignore_php_platform_requirements": {
+        "8.4": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "extra": {
     },
     "require": {
-        "php": "~8.2.0 || ~8.3.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "dflydev/fig-cookies": "^2.0.1 || ^3.0",
         "laminas/laminas-cli": "^1.8",
         "laminas/laminas-diactoros": "^2.25.2 || ^3.0",
@@ -56,7 +56,7 @@
         "laminas/laminas-servicemanager": "^3.20",
         "phpunit/phpunit": "^10.5",
         "psalm/plugin-phpunit": "^0.18.4",
-        "swoole/ide-helper": "^5.0.3",
+        "swoole/ide-helper": "^6.0",
         "vimeo/psalm": "^5.19"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7889e27593f51ecf32844e51c3c17e59",
+    "content-hash": "02c91fe29f2a28b890a31b6da25a1697",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -5093,16 +5093,16 @@
         },
         {
             "name": "swoole/ide-helper",
-            "version": "5.1.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swoole/ide-helper.git",
-                "reference": "69b374d982e7139fc904cc61757e7fede1d9c3d8"
+                "reference": "86a61562a1f1634339ee52f3b8988591f51a2799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swoole/ide-helper/zipball/69b374d982e7139fc904cc61757e7fede1d9c3d8",
-                "reference": "69b374d982e7139fc904cc61757e7fede1d9c3d8",
+                "url": "https://api.github.com/repos/swoole/ide-helper/zipball/86a61562a1f1634339ee52f3b8988591f51a2799",
+                "reference": "86a61562a1f1634339ee52f3b8988591f51a2799",
                 "shasum": ""
             },
             "type": "library",
@@ -5119,9 +5119,9 @@
             "description": "IDE help files for Swoole.",
             "support": {
                 "issues": "https://github.com/swoole/ide-helper/issues",
-                "source": "https://github.com/swoole/ide-helper/tree/5.1.1"
+                "source": "https://github.com/swoole/ide-helper/tree/6.0.0"
             },
-            "time": "2023-12-08T17:56:23+00:00"
+            "time": "2025-01-03T19:08:24+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -5404,13 +5404,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~8.2.0 || ~8.3.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2.99"
     },

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -77,12 +77,6 @@
         <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Http/Server.php" />
         <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Http2/Client.php" />
         <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Iterator.php" />
-        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/MySQL.php" />
-        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/MySQL/Exception.php" />
-        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/MySQL/Statement.php" />
-        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/PostgreSQL.php" />
-        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/PostgreSQLStatement.php" />
-        <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Redis.php" />
         <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Scheduler.php" />
         <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Socket.php" />
         <file name="vendor/swoole/ide-helper/src/swoole/Swoole/Coroutine/Socket/Exception.php" />

--- a/src/HttpServerFactory.php
+++ b/src/HttpServerFactory.php
@@ -111,7 +111,7 @@ class HttpServerFactory
 
         $enableCoroutine = $swooleConfig['enable_coroutine'] ?? false;
         if ($enableCoroutine && method_exists(SwooleRuntime::class, 'enableCoroutine')) {
-            SwooleRuntime::enableCoroutine(true);
+            SwooleRuntime::enableCoroutine();
         }
 
         $httpServer    = new SwooleHttpServer($host, $port, $mode, $protocol);


### PR DESCRIPTION
### Description

Allow PHP 8.4 in composer.

This also requires ext-swoole to be updated to 6.0.0 but as we support both swoole and openswoole there's nothing I can do about that requirement in composer.json other than updating ide-helpers.
Looking at #101 it doesn't seem like it's been an issue in the past.
