### PR TITLE
refactor: enforce strict typing

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: shivammathur/setup-php@2.34.1
         with:
           php-version: ${{ env.default_php }}
+          extensions: swoole
           tools: composer
       - uses: ramsey/composer-install@v3
       - run: composer rector

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,21 @@ on:
     branches:
     tags:
 
+env:
+  default_php: 8.2
+
 jobs:
   ci:
     uses: laminas/workflow-continuous-integration/.github/workflows/continuous-integration.yml@1.x
+
+  rector:
+    runs-on: ubuntu-latest
+    name: Run Rector on PHP
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: shivammathur/setup-php@2.34.1
+        with:
+          php-version: ${{ env.default_php }}
+          tools: composer
+      - uses: ramsey/composer-install@v3
+      - run: composer rector

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "laminas/laminas-servicemanager": "^4.0",
         "phpunit/phpunit": "^10.5",
         "psalm/plugin-phpunit": "^0.19.5",
+        "rector/rector": "^2.1",
         "swoole/ide-helper": "^6.0",
         "vimeo/psalm": "^6.13"
     },
@@ -77,11 +78,16 @@
     "scripts": {
         "check": [
             "@cs-check",
+            "@rector",
             "@test"
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "rector": "rector -n -vv",
+        "rector:fix": "rector -vv",
         "static-analysis": "psalm --shepherd --stats",
+        "static-analysis:b": "psalm --update-baseline",
+        "static-analysis:clear": "psalm --clear-cache",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "efef9d23d401b4f677db2fe64c1cbb36",
+    "content-hash": "3605e5a12aa3b16b329f3b89ff41176d",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
-            "version": "v3.1.0",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-fig-cookies.git",
-                "reference": "ebe6c15c9895fc490efe620ad734c8ef4a85bdb0"
+                "reference": "f9c63878e75483800477db4f897237b36556617b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/ebe6c15c9895fc490efe620ad734c8ef4a85bdb0",
-                "reference": "ebe6c15c9895fc490efe620ad734c8ef4a85bdb0",
+                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/f9c63878e75483800477db4f897237b36556617b",
+                "reference": "f9c63878e75483800477db4f897237b36556617b",
                 "shasum": ""
             },
             "require": {
@@ -64,9 +64,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-fig-cookies/issues",
-                "source": "https://github.com/dflydev/dflydev-fig-cookies/tree/v3.1.0"
+                "source": "https://github.com/dflydev/dflydev-fig-cookies/tree/v3.2.0"
             },
-            "time": "2023-07-18T20:41:43+00:00"
+            "time": "2025-09-03T20:01:04+00:00"
         },
         {
             "name": "fig/http-message-util",
@@ -126,35 +126,37 @@
         },
         {
             "name": "laminas/laminas-cli",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cli.git",
-                "reference": "cc59875b2a983b05a70abf4f9b3af739b1257f34"
+                "reference": "159b48f896fb2502cb6618a95307b56a0f23e592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/cc59875b2a983b05a70abf4f9b3af739b1257f34",
-                "reference": "cc59875b2a983b05a70abf4f9b3af739b1257f34",
+                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/159b48f896fb2502cb6618a95307b56a0f23e592",
+                "reference": "159b48f896fb2502cb6618a95307b56a0f23e592",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/console": "^6.0 || ^7.0",
                 "symfony/event-dispatcher": "^6.0 || ^7.0",
-                "symfony/polyfill-php80": "^1.17",
                 "webmozart/assert": "^1.10"
             },
+            "conflict": {
+                "amphp/amp": "<2.6.4"
+            },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-mvc": "^3.7.0",
-                "laminas/laminas-servicemanager": "^3.22.1",
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-mvc": "^3.8.0",
+                "laminas/laminas-servicemanager": "^3.23.0",
                 "mikey179/vfsstream": "2.0.x-dev",
-                "phpunit/phpunit": "^10.5.5",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.18"
+                "phpunit/phpunit": "^10.5.38",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "bin": [
                 "bin/laminas"
@@ -190,29 +192,32 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-01-02T15:08:03+00:00"
+            "time": "2024-11-22T12:39:15+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "3.3.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "4db52734837c60259c9b2d7caf08eef8f7f9b9ac"
+                "reference": "b068eac123f21c0e592de41deeb7403b88e0a89f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/4db52734837c60259c9b2d7caf08eef8f7f9b9ac",
-                "reference": "4db52734837c60259c9b2d7caf08eef8f7f9b9ac",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/b068eac123f21c0e592de41deeb7403b88e0a89f",
+                "reference": "b068eac123f21c0e592de41deeb7403b88e0a89f",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-                "psr/http-factory": "^1.0.2",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/http-factory": "^1.1",
                 "psr/http-message": "^1.1 || ^2.0"
             },
+            "conflict": {
+                "amphp/amp": "<2.6.4"
+            },
             "provide": {
-                "psr/http-factory-implementation": "^1.1 || ^2.0",
+                "psr/http-factory-implementation": "^1.0",
                 "psr/http-message-implementation": "^1.1 || ^2.0"
             },
             "require-dev": {
@@ -220,18 +225,18 @@
                 "ext-dom": "*",
                 "ext-gd": "*",
                 "ext-libxml": "*",
-                "http-interop/http-factory-tests": "^0.9.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "php-http/psr7-integration-tests": "^1.3",
-                "phpunit/phpunit": "^9.5.28",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15.0"
+                "http-interop/http-factory-tests": "^2.2.0",
+                "laminas/laminas-coding-standard": "~3.0.0",
+                "php-http/psr7-integration-tests": "^1.4.0",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "type": "library",
             "extra": {
                 "laminas": {
-                    "config-provider": "Laminas\\Diactoros\\ConfigProvider",
-                    "module": "Laminas\\Diactoros"
+                    "module": "Laminas\\Diactoros",
+                    "config-provider": "Laminas\\Diactoros\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -275,37 +280,36 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-26T11:01:07+00:00"
+            "time": "2025-05-05T16:03:34+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.13.0",
+            "version": "2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "af459883f4018d0f8a0c69c7a209daef3bf973ba"
+                "reference": "df1ef9503299a8e3920079a16263b578eaf7c3ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/af459883f4018d0f8a0c69c7a209daef3bf973ba",
-                "reference": "af459883f4018d0f8a0c69c7a209daef3bf973ba",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/df1ef9503299a8e3920079a16263b578eaf7c3ba",
+                "reference": "df1ef9503299a8e3920079a16263b578eaf7c3ba",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-mbstring": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
                 "zendframework/zend-escaper": "*"
             },
             "require-dev": {
-                "infection/infection": "^0.27.0",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "maglnet/composer-require-checker": "^3.8.0",
-                "phpunit/phpunit": "^9.6.7",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.9"
+                "infection/infection": "^0.29.8",
+                "laminas/laminas-coding-standard": "~3.0.1",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "vimeo/psalm": "^6.6.2"
             },
             "type": "library",
             "autoload": {
@@ -337,34 +341,34 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-10T08:35:13+00:00"
+            "time": "2025-05-06T19:29:36+00:00"
         },
         {
             "name": "laminas/laminas-httphandlerrunner",
-            "version": "2.10.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
-                "reference": "35a0ba92e940a2f9533754f5a56187fa321f7693"
+                "reference": "b14da3519c650e9436e410cfedee6f860312eff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/35a0ba92e940a2f9533754f5a56187fa321f7693",
-                "reference": "35a0ba92e940a2f9533754f5a56187fa321f7693",
+                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/b14da3519c650e9436e410cfedee6f860312eff9",
+                "reference": "b14da3519c650e9436e410cfedee6f860312eff9",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/http-message": "^1.0 || ^2.0",
                 "psr/http-message-implementation": "^1.0 || ^2.0",
                 "psr/http-server-handler": "^1.0"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-diactoros": "^3.3.0",
-                "phpunit/phpunit": "^10.5.5",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.18"
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-diactoros": "^3.6.0",
+                "phpunit/phpunit": "^10.5.46",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.3"
             },
             "type": "library",
             "extra": {
@@ -404,26 +408,26 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-01-04T10:50:34+00:00"
+            "time": "2025-05-13T21:21:16+00:00"
         },
         {
             "name": "laminas/laminas-stratigility",
-            "version": "3.11.0",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stratigility.git",
-                "reference": "4dee4580a8efea63a8b2b24dbf4604ee480e8cd6"
+                "reference": "3df57528b5c8e9d958515c51006825a83f76d62b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/4dee4580a8efea63a8b2b24dbf4604ee480e8cd6",
-                "reference": "4dee4580a8efea63a8b2b24dbf4604ee480e8cd6",
+                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/3df57528b5c8e9d958515c51006825a83f76d62b",
+                "reference": "3df57528b5c8e9d958515c51006825a83f76d62b",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1",
                 "laminas/laminas-escaper": "^2.10.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/http-message": "^1.0 || ^2.0",
                 "psr/http-server-middleware": "^1.0.2"
             },
@@ -432,10 +436,10 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-diactoros": "^2.25 || ^3.3",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15.0"
+                "laminas/laminas-diactoros": "^2.25 || ^3.5.0",
+                "phpunit/phpunit": "^10.5.37",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., laminas/laminas-diactoros"
@@ -483,20 +487,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-31T16:26:05+00:00"
+            "time": "2024-10-28T11:28:41+00:00"
         },
         {
             "name": "mezzio/mezzio",
-            "version": "3.18.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio.git",
-                "reference": "450512a378967d23243f784808a8436bc7a125a7"
+                "reference": "1ec7e77a0532984c30d18e7278d9bbc596c6293a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/450512a378967d23243f784808a8436bc7a125a7",
-                "reference": "450512a378967d23243f784808a8436bc7a125a7",
+                "url": "https://api.github.com/repos/mezzio/mezzio/zipball/1ec7e77a0532984c30d18e7278d9bbc596c6293a",
+                "reference": "1ec7e77a0532984c30d18e7278d9bbc596c6293a",
                 "shasum": ""
             },
             "require": {
@@ -505,12 +509,12 @@
                 "laminas/laminas-stratigility": "^3.5",
                 "mezzio/mezzio-router": "^3.7",
                 "mezzio/mezzio-template": "^2.2",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/container": "^1.0||^2.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0.1 || ^2.0.0",
                 "psr/http-server-middleware": "^1.0",
-                "webmozart/assert": "^1.10"
+                "webmozart/assert": "^1.11.0"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2.0",
@@ -522,16 +526,15 @@
                 "zendframework/zend-expressive": "*"
             },
             "require-dev": {
-                "filp/whoops": "^2.15.4",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-diactoros": "^3.3.0",
-                "laminas/laminas-servicemanager": "^3.22.1",
-                "mezzio/mezzio-aurarouter": "^3.6",
-                "mezzio/mezzio-fastroute": "^3.11",
-                "mezzio/mezzio-laminasrouter": "^3.8",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15.0"
+                "filp/whoops": "^2.18.0",
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "laminas/laminas-diactoros": "^3.5.0",
+                "laminas/laminas-servicemanager": "^3.23.0",
+                "mezzio/mezzio-fastroute": "^3.13",
+                "mezzio/mezzio-laminasrouter": "^3.11",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.1"
             },
             "suggest": {
                 "filp/whoops": "^2.1 to use the Whoops error handler",
@@ -590,25 +593,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-11-03T13:17:33+00:00"
+            "time": "2025-04-27T12:45:58+00:00"
         },
         {
             "name": "mezzio/mezzio-router",
-            "version": "3.17.0",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-router.git",
-                "reference": "78573e16144a70ccf02039e1a2600788119c0dbb"
+                "reference": "75e9a3e636ee69f3a51006772cf29c00cb5da675"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/78573e16144a70ccf02039e1a2600788119c0dbb",
-                "reference": "78573e16144a70ccf02039e1a2600788119c0dbb",
+                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/75e9a3e636ee69f3a51006772cf29c00cb5da675",
+                "reference": "75e9a3e636ee69f3a51006772cf29c00cb5da675",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.5",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/container": "^1.1.2 || ^2.0",
                 "psr/http-factory": "^1.0.2",
                 "psr/http-message": "^1.0.1 || ^2.0.0",
@@ -621,12 +624,12 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-diactoros": "^3.3.0",
-                "laminas/laminas-servicemanager": "^3.22.1",
-                "laminas/laminas-stratigility": "^3.11.0",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15"
+                "laminas/laminas-diactoros": "^3.4.0",
+                "laminas/laminas-servicemanager": "^4.2.0",
+                "laminas/laminas-stratigility": "^4.0.2",
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",
@@ -672,33 +675,33 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-31T17:23:17+00:00"
+            "time": "2024-10-16T21:18:01+00:00"
         },
         {
             "name": "mezzio/mezzio-template",
-            "version": "2.10.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-template.git",
-                "reference": "2cc943c996b8a63f1f945a2b891346ecbc8f7a33"
+                "reference": "836b7e55f92277d5c557f96895d13a547c4abf14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/2cc943c996b8a63f1f945a2b891346ecbc8f7a33",
-                "reference": "2cc943c996b8a63f1f945a2b891346ecbc8f7a33",
+                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/836b7e55f92277d5c557f96895d13a547c4abf14",
+                "reference": "836b7e55f92277d5c557f96895d13a547c4abf14",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "conflict": {
                 "zendframework/zend-expressive-template": "*"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.15"
+                "phpunit/phpunit": "^10.5.36",
+                "psalm/plugin-phpunit": "^0.19.0",
+                "vimeo/psalm": "^5.26.1"
             },
             "suggest": {
                 "mezzio/mezzio-laminasviewrenderer": "^2.0 to use the laminas-view PhpRenderer template renderer",
@@ -736,26 +739,31 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-01-08T15:20:45+00:00"
+            "time": "2024-10-16T20:54:53+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -782,9 +790,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -1274,24 +1282,24 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.4.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "e95216850555cd55e71b857eb9d6c2674124603a"
+                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e95216850555cd55e71b857eb9d6c2674124603a",
-                "reference": "e95216850555cd55e71b857eb9d6c2674124603a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b7dc69e71de420ac04bc9ab830cf3ffebba48191",
+                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -1300,13 +1308,13 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^5.4|^6.0|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0"
+                "symfony/stopwatch": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -1334,7 +1342,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.2"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -1346,24 +1354,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-27T22:16:42+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.4.0",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df"
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/a76aed96a42d2b521153fb382d418e30d18b59df",
-                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
                 "shasum": ""
             },
             "require": {
@@ -1372,12 +1384,12 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
                 "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -1410,7 +1422,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -1426,7 +1438,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1762,90 +1774,6 @@
                 }
             ],
             "time": "2024-12-23T08:48:59+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3258,35 +3186,38 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3296,17 +3227,16 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -3326,10 +3256,29 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -3367,6 +3316,54 @@
                 "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
             },
             "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+            },
+            "time": "2025-04-07T20:06:18+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -3487,26 +3484,26 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.15.4",
+            "version": "2.18.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546"
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/a139776fa3f5985a50b509f2a02ff0f709d2a546",
-                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/d2102955e48b9fd9ab24280a7ad12ed552752c4d",
+                "reference": "d2102955e48b9fd9ab24280a7ad12ed552752c4d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9 || ^7.0 || ^8.0",
+                "php": "^7.1 || ^8.0",
                 "psr/log": "^1.0.1 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9 || ^1.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.3",
-                "symfony/var-dumper": "^2.6 || ^3.0 || ^4.0 || ^5.0"
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.8 || ^9.3.3",
+                "symfony/var-dumper": "^4.0 || ^5.0"
             },
             "suggest": {
                 "symfony/var-dumper": "Pretty print complex values better with var-dumper available",
@@ -3546,7 +3543,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.15.4"
+                "source": "https://github.com/filp/whoops/tree/2.18.4"
             },
             "funding": [
                 {
@@ -3554,7 +3551,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-03T12:00:00+00:00"
+            "time": "2025-08-08T12:00:00+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -4327,28 +4324,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.3.0",
+            "version": "5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
+                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94f8051919d1b0369a6bcc7931d679a511c03fe9",
+                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9",
                 "shasum": ""
             },
             "require": {
+                "doctrine/deprecations": "^1.1",
                 "ext-filter": "*",
-                "php": "^7.2 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.3",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2",
-                "psalm/phar": "^4.8"
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
             },
             "type": "library",
             "extra": {
@@ -4372,36 +4376,39 @@
                 },
                 {
                     "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
+                    "email": "opensource@ijaap.nl"
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.3"
             },
-            "time": "2021-10-19T17:43:47+00:00"
+            "time": "2025-08-01T19:43:32+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.2",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d"
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
-                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.1",
@@ -4433,9 +4440,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.2"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
             },
-            "time": "2022-10-14T12:47:21+00:00"
+            "time": "2024-11-09T15:12:26+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -4483,6 +4490,64 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
             },
             "time": "2025-08-30T15:50:23+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.25",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "4087d28bd252895874e174d65e26b2c202ed893a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4087d28bd252895874e174d65e26b2c202ed893a",
+                "reference": "4087d28bd252895874e174d65e26b2c202ed893a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-12T14:26:42+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4971,6 +5036,66 @@
                 "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.5"
             },
             "time": "2025-03-31T18:49:55+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/c34cc07c4698f007a20dc5c99ff820089ae413ce",
+                "reference": "c34cc07c4698f007a20dc5c99ff820089ae413ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.18"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.1.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-10T11:13:58+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -6554,21 +6679,21 @@
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.3.2",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "710f71ac95d36d931e76b47132b599c39abfab11"
+                "reference": "6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/710f71ac95d36d931e76b47132b599c39abfab11",
-                "reference": "710f71ac95d36d931e76b47132b599c39abfab11",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53",
+                "reference": "6f6a1a90bd9e18fc8bee0660dd1d1ce68cf9fc53",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.7.2"
+                "squizlabs/php_codesniffer": "^3.10.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.6.15"
@@ -6597,7 +6722,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.3.2"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.4.0"
             },
             "funding": [
                 {
@@ -6605,7 +6730,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-18T07:25:41+00:00"
+            "time": "2024-10-16T06:55:17+00:00"
         }
     ],
     "aliases": [],

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,6 +14,7 @@
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+    <file>rector.php</file>
 
     <!-- Include all rules from Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard" />

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -4,16 +4,6 @@
     <MixedArrayOffset>
       <code><![CDATA[$cacheControlDirectives[$regex]]]></code>
     </MixedArrayOffset>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$clearStatCacheInterval]]></code>
-    </RiskyTruthyFalsyComparison>
-  </file>
-  <file src="src/Command/IsRunningTrait.php">
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$managerPid]]></code>
-      <code><![CDATA[$masterPid]]></code>
-      <code><![CDATA[$masterPid]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Command/ReloadCommand.php">
     <DeprecatedMethod>
@@ -64,14 +54,6 @@
     <PossiblyFalseIterator>
       <code><![CDATA[scandir($path)]]></code>
     </PossiblyFalseIterator>
-    <RedundantCondition>
-      <code><![CDATA[isArray]]></code>
-    </RedundantCondition>
-  </file>
-  <file src="src/HttpServerFactory.php">
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$enableCoroutine]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Log/AccessLogDataMap.php">
     <FalsableReturnStatement>
@@ -99,64 +81,6 @@
     <PossiblyNullReference>
       <code><![CDATA[getHeaderSize]]></code>
     </PossiblyNullReference>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$port]]></code>
-      <code><![CDATA[(string) $this->psrResponse->getBody()->getSize()]]></code>
-      <code><![CDATA[getenv($name)]]></code>
-    </RiskyTruthyFalsyComparison>
-  </file>
-  <file src="src/Log/AccessLogFormatter.php">
-    <InvalidNullableReturnType>
-      <code><![CDATA[string]]></code>
-      <code><![CDATA[string]]></code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[preg_replace_callback(
-            '#%(?:[<>])?([%aABbDfhHklLmpPqrRstTuUvVXIOS])#',
-            static fn(array $matches) => match ($matches[1]) {
-                '%' => '%',
-                'a' => $map->getClientIp(),
-                'A' => $map->getLocalIp(),
-                'B' => $map->getBodySize('0'),
-                'b' => $map->getBodySize('-'),
-                'D' => $map->getRequestDuration('ms'),
-                'f' => $map->getFilename(),
-                'h' => $map->getRemoteHostname(),
-                'H' => $map->getProtocol(),
-                'm' => $map->getMethod(),
-                'p' => $map->getPort('canonical'),
-                'q' => $map->getQuery(),
-                'r' => $map->getRequestLine(),
-                's' => $map->getStatus(),
-                't' => $map->getRequestTime('begin:%d/%b/%Y:%H:%M:%S %z'),
-                'T' => $map->getRequestDuration('s'),
-                'u' => $map->getRemoteUser(),
-                'U' => $map->getPath(),
-                'v' => $map->getHost(),
-                'V' => $map->getServerName(),
-                'I' => (string) ($map->getRequestMessageSize() ?? '-'),
-                'O' => (string) ($map->getResponseMessageSize() ?? '-'),
-                'S' => $map->getTransferredSize(),
-                default => '-',
-            },
-            $format
-        )]]></code>
-      <code><![CDATA[preg_replace_callback(
-            '#%(?:[<>])?{([^}]+)}([aCeinopPtT])#',
-            static fn(array $matches) => match ($matches[2]) {
-                'a' => $map->getClientIp(),
-                'C' => $map->getCookie($matches[1]),
-                'e' => $map->getEnv($matches[1]),
-                'i' => $map->getRequestHeader($matches[1]),
-                'o' => $map->getResponseHeader($matches[1]),
-                'p' => $map->getPort($matches[1]),
-                't' => $map->getRequestTime($matches[1]),
-                'T' => $map->getRequestDuration($matches[1]),
-                default => '-',
-            },
-            $format
-        )]]></code>
-    </NullableReturnStatement>
   </file>
   <file src="src/Log/Psr3AccessLogDecorator.php">
     <MissingParamType>
@@ -195,9 +119,6 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$middleware]]></code>
     </MixedPropertyTypeCoercion>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[! $filename]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/StaticResourceHandler.php">
     <MixedOperand>
@@ -214,9 +135,6 @@
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$cacheControlDirectives]]></code>
     </MixedPropertyTypeCoercion>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$cacheControl]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/StaticResourceHandler/ETagMiddleware.php">
     <ArgumentTypeCoercion>
@@ -228,11 +146,6 @@
     <PossiblyFalseArgument>
       <code><![CDATA[$etag]]></code>
     </PossiblyFalseArgument>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$ifMatch]]></code>
-      <code><![CDATA[filemtime($filename)]]></code>
-      <code><![CDATA[filesize($filename)]]></code>
-    </RiskyTruthyFalsyComparison>
     <UnusedProperty>
       <code><![CDATA[$allowedETagValidationTypes]]></code>
     </UnusedProperty>
@@ -269,17 +182,11 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$regexp]]></code>
     </ArgumentTypeCoercion>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[filemtime($filename)]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/StaticResourceHandler/StaticResourceResponse.php">
     <PossiblyFalsePropertyAssignmentValue>
       <code><![CDATA[filesize($filename)]]></code>
     </PossiblyFalsePropertyAssignmentValue>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$responseContentCallback]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/StaticResourceHandler/ValidateRegexTrait.php">
     <ArgumentTypeCoercion>
@@ -295,10 +202,6 @@
     <PossiblyNullReference>
       <code><![CDATA[asString]]></code>
     </PossiblyNullReference>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$cookie->getDomain()]]></code>
-      <code><![CDATA[$cookie->getPath()]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/SwooleRequestHandlerRunner.php">
     <PossiblyUnusedReturnValue>
@@ -319,11 +222,6 @@
     <PossiblyUnusedReturnValue>
       <code><![CDATA[int]]></code>
     </PossiblyUnusedReturnValue>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[$key]]></code>
-      <code><![CDATA[$this->body]]></code>
-      <code><![CDATA[$this->request->rawContent()]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Task/DeferredListenerDelegator.php">
     <UnusedParam>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -115,11 +115,6 @@
       <code><![CDATA[bool]]></code>
     </PossiblyUnusedReturnValue>
   </file>
-  <file src="src/StaticMappedResourceHandler.php">
-    <MixedPropertyTypeCoercion>
-      <code><![CDATA[$middleware]]></code>
-    </MixedPropertyTypeCoercion>
-  </file>
   <file src="src/StaticResourceHandler.php">
     <MixedOperand>
       <code><![CDATA[$request->server['request_uri']]]></code>
@@ -258,12 +253,6 @@
       <code><![CDATA[assertAttributeEmpty]]></code>
       <code><![CDATA[assertAttributeEmpty]]></code>
     </PossiblyUnusedMethod>
-    <PossiblyUnusedParam>
-      <code><![CDATA[$canonicalize]]></code>
-      <code><![CDATA[$delta]]></code>
-      <code><![CDATA[$ignoreCase]]></code>
-      <code><![CDATA[$maxDepth]]></code>
-    </PossiblyUnusedParam>
   </file>
   <file src="test/Command/ReloadCommandTest.php">
     <DeprecatedMethod>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
+
+return RectorConfig::configure()
+    ->withPhpSets(php82: true)
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/test',
+    ])
+    ->withPreparedSets(
+        typeDeclarations: true,
+    )
+    ->withSkip([
+        __DIR__ . '/test/TestAsset',
+        //  $this->httpServer->on('managerstart', [$this, 'onManagerStart']);
+        // vs
+        // $this->httpServer->on('managerstart', $this->onManagerStart(...)
+        // is not the same
+        FirstClassCallableRector::class => [
+            __DIR__ . '/src/SwooleRequestHandlerRunner.php',
+            __DIR__ . '/test/SwooleRequestHandlerRunnerTest.php',
+            __DIR__ . '/test/Task/TaskTest.php',
+        ],
+        // Rector try to set callable as Closure. These are not the same — Closure is a subtype of callable.
+        TypedPropertyFromStrictSetUpRector::class => [
+            __DIR__ . '/test/StaticResourceHandler/LastModifiedMiddlewareTest.php',
+            __DIR__ . '/test/StaticResourceHandler/HeadMiddlewareTest.php',
+            __DIR__ . '/test/StaticResourceHandler/GzipMiddlewareTest.php',
+            __DIR__ . '/test/StaticResourceHandler/ETagMiddlewareTest.php',
+        ],
+    ]);

--- a/src/AbstractStaticResourceHandlerFactory.php
+++ b/src/AbstractStaticResourceHandlerFactory.php
@@ -23,8 +23,7 @@ use function is_string;
 
 abstract class AbstractStaticResourceHandlerFactory
 {
-    /** @return StaticResourceHandlerInterface */
-    abstract public function __invoke(ContainerInterface $container);
+    abstract public function __invoke(ContainerInterface $container): StaticResourceHandlerInterface;
 
     /**
      * Prepare the list of middleware based on configuration provided.
@@ -70,7 +69,7 @@ abstract class AbstractStaticResourceHandlerFactory
         }
 
         $clearStatCacheInterval = $config['clearstatcache-interval'] ?? false;
-        if ($clearStatCacheInterval) {
+        if ($clearStatCacheInterval !== false) {
             $middleware[] = new ClearStatCacheMiddleware((int) $clearStatCacheInterval);
         }
 

--- a/src/Command/IsRunningTrait.php
+++ b/src/Command/IsRunningTrait.php
@@ -30,12 +30,12 @@ trait IsRunningTrait
 
         [$masterPid, $managerPid] = array_pad($pids, 2, null);
 
-        if ($managerPid) {
+        if ($managerPid !== null) {
             // Swoole process mode
-            return $masterPid && SwooleProcess::kill((int) $managerPid, 0);
+            return $masterPid !== null && SwooleProcess::kill((int) $managerPid, 0);
         }
 
         // Swoole base mode, no manager process
-        return $masterPid && SwooleProcess::kill((int) $masterPid, 0);
+        return $masterPid !== null && SwooleProcess::kill((int) $masterPid, 0);
     }
 }

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -42,7 +42,7 @@ EOH;
      */
     public static $defaultName = 'mezzio:swoole:reload';
 
-    public function __construct(private int $serverMode)
+    public function __construct(private readonly int $serverMode)
     {
         parent::__construct();
     }

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -59,7 +59,7 @@ EOH;
 
     public function __construct(private PidManager $pidManager)
     {
-        $this->killProcess = Closure::fromCallable([SwooleProcess::class, 'kill']);
+        $this->killProcess = SwooleProcess::kill(...);
         parent::__construct();
     }
 

--- a/src/Event/AbstractTaskEvent.php
+++ b/src/Event/AbstractTaskEvent.php
@@ -10,8 +10,7 @@ namespace Mezzio\Swoole\Event;
 
 abstract class AbstractTaskEvent extends AbstractServerAwareEvent
 {
-    /** @var mixed */
-    protected $data;
+    protected mixed $data;
 
     protected int $taskId;
 
@@ -20,8 +19,7 @@ abstract class AbstractTaskEvent extends AbstractServerAwareEvent
         return $this->taskId;
     }
 
-    /** @return mixed */
-    public function getData()
+    public function getData(): mixed
     {
         return $this->data;
     }

--- a/src/Event/EventDispatcher.php
+++ b/src/Event/EventDispatcher.php
@@ -14,14 +14,14 @@ use Psr\EventDispatcher\StoppableEventInterface;
 
 class EventDispatcher implements EventDispatcherInterface
 {
-    public function __construct(private ListenerProviderInterface $listenerProvider)
+    public function __construct(private readonly ListenerProviderInterface $listenerProvider)
     {
     }
 
     /**
      * @return object Returns the event passed to the method.
      */
-    public function dispatch(object $event)
+    public function dispatch(object $event): object
     {
         $stoppable = $event instanceof StoppableEventInterface;
 

--- a/src/Event/HotCodeReloaderWorkerStartListener.php
+++ b/src/Event/HotCodeReloaderWorkerStartListener.php
@@ -19,9 +19,9 @@ class HotCodeReloaderWorkerStartListener
         /**
          * A file watcher to monitor changes in files.
          */
-        private FileWatcherInterface $fileWatcher,
-        private LoggerInterface $logger,
-        private int $interval
+        private readonly FileWatcherInterface $fileWatcher,
+        private readonly LoggerInterface $logger,
+        private readonly int $interval
     ) {
     }
 

--- a/src/Event/RequestEvent.php
+++ b/src/Event/RequestEvent.php
@@ -16,8 +16,10 @@ class RequestEvent implements StoppableEventInterface
 {
     private bool $responseSent = false;
 
-    public function __construct(private SwooleHttpRequest $request, private SwooleHttpResponse $response)
-    {
+    public function __construct(
+        private readonly SwooleHttpRequest $request,
+        private readonly SwooleHttpResponse $response
+    ) {
     }
 
     public function isPropagationStopped(): bool

--- a/src/Event/RequestHandlerRequestListener.php
+++ b/src/Event/RequestHandlerRequestListener.php
@@ -62,10 +62,10 @@ class RequestHandlerRequestListener
     private $serverRequestFactory;
 
     public function __construct(
-        private RequestHandlerInterface $requestHandler,
+        private readonly RequestHandlerInterface $requestHandler,
         callable $serverRequestFactory,
         callable $serverRequestErrorResponseGenerator,
-        private AccessLogInterface $logger,
+        private readonly AccessLogInterface $logger,
         ?callable $emitterFactory = null
     ) {
         // Factories are cast as Closures to ensure return type safety.

--- a/src/Event/ServerShutdownEvent.php
+++ b/src/Event/ServerShutdownEvent.php
@@ -12,7 +12,7 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 class ServerShutdownEvent
 {
-    public function __construct(private SwooleHttpServer $server)
+    public function __construct(private readonly SwooleHttpServer $server)
     {
     }
 

--- a/src/Event/ServerShutdownListener.php
+++ b/src/Event/ServerShutdownListener.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 
 class ServerShutdownListener
 {
-    public function __construct(private PidManager $pidManager, private LoggerInterface $logger)
+    public function __construct(private readonly PidManager $pidManager, private readonly LoggerInterface $logger)
     {
     }
 

--- a/src/Event/ServerStartEvent.php
+++ b/src/Event/ServerStartEvent.php
@@ -12,7 +12,7 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 class ServerStartEvent
 {
-    public function __construct(private SwooleHttpServer $server)
+    public function __construct(private readonly SwooleHttpServer $server)
     {
     }
 

--- a/src/Event/StaticResourceRequestListener.php
+++ b/src/Event/StaticResourceRequestListener.php
@@ -15,8 +15,8 @@ use Mezzio\Swoole\StaticResourceHandlerInterface;
 class StaticResourceRequestListener
 {
     public function __construct(
-        private StaticResourceHandlerInterface $staticResourceHandler,
-        private AccessLogInterface $logger
+        private readonly StaticResourceHandlerInterface $staticResourceHandler,
+        private readonly AccessLogInterface $logger
     ) {
     }
 

--- a/src/Event/TaskEvent.php
+++ b/src/Event/TaskEvent.php
@@ -13,14 +13,16 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 class TaskEvent extends AbstractTaskEvent implements StoppableEventInterface
 {
-    /** @var mixed */
-    private $returnValue;
+    private mixed $returnValue;
 
     private bool $taskProcessed = false;
 
-    /** @param mixed $data */
-    public function __construct(SwooleHttpServer $server, int $taskId, private int $workerId, $data)
-    {
+    public function __construct(
+        SwooleHttpServer $server,
+        int $taskId,
+        private readonly int $workerId,
+        mixed $data
+    ) {
         $this->server = $server;
         $this->taskId = $taskId;
         $this->data   = $data;
@@ -41,8 +43,7 @@ class TaskEvent extends AbstractTaskEvent implements StoppableEventInterface
         $this->returnValue = $returnValue;
     }
 
-    /** @return mixed */
-    public function getReturnValue()
+    public function getReturnValue(): mixed
     {
         return $this->returnValue;
     }

--- a/src/Event/TaskFinishEvent.php
+++ b/src/Event/TaskFinishEvent.php
@@ -12,9 +12,11 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 class TaskFinishEvent extends AbstractTaskEvent
 {
-    /** @param mixed $data */
-    public function __construct(SwooleHttpServer $server, int $taskId, $data)
-    {
+    public function __construct(
+        SwooleHttpServer $server,
+        int $taskId,
+        mixed $data
+    ) {
         $this->server = $server;
         $this->taskId = $taskId;
         $this->data   = $data;

--- a/src/Event/WorkerErrorEvent.php
+++ b/src/Event/WorkerErrorEvent.php
@@ -12,8 +12,12 @@ use Swoole\Http\Server as SwooleHttpServer;
 
 class WorkerErrorEvent extends AbstractSwooleWorkerEvent
 {
-    public function __construct(SwooleHttpServer $server, int $workerId, private int $exitCode, private int $signal)
-    {
+    public function __construct(
+        SwooleHttpServer $server,
+        int $workerId,
+        private readonly int $exitCode,
+        private readonly int $signal
+    ) {
         $this->server   = $server;
         $this->workerId = $workerId;
     }

--- a/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
+++ b/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
@@ -74,7 +74,6 @@ class InotifyFileWatcher implements FileWatcherInterface
         $paths  = [];
         if (is_array($events)) {
             foreach ($events as $event) {
-                Assert::isArray($event);
                 /** @var ?string $wd */
                 $wd = $event['wd'] ?? null;
                 if (null === $wd) {

--- a/src/HttpServerFactory.php
+++ b/src/HttpServerFactory.php
@@ -110,7 +110,7 @@ class HttpServerFactory
         }
 
         $enableCoroutine = $swooleConfig['enable_coroutine'] ?? false;
-        if ($enableCoroutine && method_exists(SwooleRuntime::class, 'enableCoroutine')) {
+        if ($enableCoroutine !== false && method_exists(SwooleRuntime::class, 'enableCoroutine')) {
             SwooleRuntime::enableCoroutine();
         }
 

--- a/src/Log/AccessLogDataMap.php
+++ b/src/Log/AccessLogDataMap.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ResponseInterface as PsrResponse;
 use RuntimeException;
 use Swoole\Http\Request as SwooleHttpRequest;
 
+use function array_key_exists;
 use function filter_var;
 use function function_exists;
 use function getcwd;
@@ -23,6 +24,7 @@ use function gethostbyaddr;
 use function gethostname;
 use function http_build_query;
 use function implode;
+use function is_numeric;
 use function is_string;
 use function microtime;
 use function preg_match;
@@ -46,7 +48,7 @@ class AccessLogDataMap
     /**
      * Timestamp when created, indicating end of request processing.
      */
-    private float $endTime;
+    private readonly float $endTime;
 
     private ?PsrResponse $psrResponse = null;
 
@@ -126,7 +128,9 @@ class AccessLogDataMap
     public function getBodySize(string $default): string
     {
         if ($this->psrResponse !== null) {
-            return (string) $this->psrResponse->getBody()->getSize() ?: $default;
+            $size = $this->psrResponse->getBody()->getSize();
+
+            return $size === null ? $default : (string) $size;
         }
 
         if ($this->staticResource !== null) {
@@ -200,7 +204,8 @@ class AccessLogDataMap
      */
     public function getEnv(string $name): string
     {
-        return getenv($name) ?: '-';
+        $value = getenv($name);
+        return $value === false ? '-' : $value;
     }
 
     /**
@@ -220,8 +225,10 @@ class AccessLogDataMap
             case 'canonical':
             case 'local':
                 preg_match(self::HOST_PORT_REGEX, $this->request->header['host'] ?? '', $matches);
-                $port   = $matches['port'] ?? null;
-                $port   = $port ?: $this->getServerParam('server_port', '80');
+                $port   = array_key_exists('port', $matches) && is_numeric($matches['port'])
+                    ? (int) $matches['port']
+                    : null;
+                $port   = $port !== null ? $this->getServerParam('server_port', '80') : '80';
                 $scheme = $this->getServerParam('https', '');
                 return $scheme && $port === '80' ? '443' : $port;
             default:
@@ -332,10 +339,8 @@ class AccessLogDataMap
 
     /**
      * Get the request message size (including first line and headers)
-     *
-     * @param null|int $default
      */
-    public function getRequestMessageSize($default = null): ?int
+    public function getRequestMessageSize(?int $default = null): ?int
     {
         $strlen = function_exists('mb_strlen') ? 'mb_strlen' : 'strlen';
 
@@ -367,10 +372,8 @@ class AccessLogDataMap
 
     /**
      * Get the response message size (including first line and headers)
-     *
-     * @param null|int $default
      */
-    public function getResponseMessageSize($default = null): ?int
+    public function getResponseMessageSize(?int $default = null): ?int
     {
         if ($this->psrResponse !== null) {
             $bodySize = $this->psrResponse->getBody()->getSize();
@@ -443,8 +446,8 @@ class AccessLogDataMap
     }
 
     private function __construct(
-        private SwooleHttpRequest $request,
-        private bool $useHostnameLookups
+        private readonly SwooleHttpRequest $request,
+        private readonly bool $useHostnameLookups
     ) {
         $this->endTime = microtime(true);
     }

--- a/src/Log/AccessLogFormatter.php
+++ b/src/Log/AccessLogFormatter.php
@@ -68,7 +68,7 @@ class AccessLogFormatter implements AccessLogFormatterInterface
         /**
          * Message format to use when generating a log message.
          */
-        private string $format = self::FORMAT_COMMON
+        private readonly string $format = self::FORMAT_COMMON
     ) {
     }
 
@@ -87,7 +87,7 @@ class AccessLogFormatter implements AccessLogFormatterInterface
     ): string {
         return preg_replace_callback(
             '#%(?:[<>])?([%aABbDfhHklLmpPqrRstTuUvVXIOS])#',
-            static fn(array $matches) => match ($matches[1]) {
+            static fn(array $matches): string => match ($matches[1]) {
                 '%' => '%',
                 'a' => $map->getClientIp(),
                 'A' => $map->getLocalIp(),
@@ -114,7 +114,7 @@ class AccessLogFormatter implements AccessLogFormatterInterface
                 default => '-',
             },
             $format
-        );
+        ) ?? $format;
     }
 
     private function replaceVariableDirectives(
@@ -123,7 +123,7 @@ class AccessLogFormatter implements AccessLogFormatterInterface
     ): string {
         return preg_replace_callback(
             '#%(?:[<>])?{([^}]+)}([aCeinopPtT])#',
-            static fn(array $matches) => match ($matches[2]) {
+            static fn(array $matches): string => match ($matches[2]) {
                 'a' => $map->getClientIp(),
                 'C' => $map->getCookie($matches[1]),
                 'e' => $map->getEnv($matches[1]),
@@ -135,6 +135,6 @@ class AccessLogFormatter implements AccessLogFormatterInterface
                 default => '-',
             },
             $format
-        );
+        ) ?? $format;
     }
 }

--- a/src/Log/Psr3AccessLogDecorator.php
+++ b/src/Log/Psr3AccessLogDecorator.php
@@ -16,13 +16,13 @@ use Swoole\Http\Request;
 class Psr3AccessLogDecorator implements AccessLogInterface
 {
     public function __construct(
-        private LoggerInterface $logger,
-        private AccessLogFormatterInterface $formatter,
+        private readonly LoggerInterface $logger,
+        private readonly AccessLogFormatterInterface $formatter,
         /**
          * Whether or not to look up remote host names when preparing the access
          * log message
          */
-        private bool $useHostnameLookups = false
+        private readonly bool $useHostnameLookups = false
     ) {
     }
 

--- a/src/Log/StrftimeToICUFormatMap.php
+++ b/src/Log/StrftimeToICUFormatMap.php
@@ -38,7 +38,7 @@ final class StrftimeToICUFormatMap
      */
     private static function generateMapCallback(DateTimeInterface $requestTime): callable
     {
-        /** @psalm-param array<array-key, string> */
+        /** @psalm-param array<array-key, string> $matches */
         return static function (array $matches) use ($requestTime): string {
             Assert::keyExists($matches, 'token');
             return match (true) {

--- a/src/PidManager.php
+++ b/src/PidManager.php
@@ -21,7 +21,7 @@ use function unlink;
 
 class PidManager
 {
-    public function __construct(private string $pidFile)
+    public function __construct(private readonly string $pidFile)
     {
     }
 

--- a/src/StaticMappedResourceHandler.php
+++ b/src/StaticMappedResourceHandler.php
@@ -43,7 +43,7 @@ class StaticMappedResourceHandler implements StaticResourceHandlerInterface
         SwooleHttpResponse $response
     ): ?StaticResourceResponse {
         $filename = $this->fileLocationRepo->findFile($request->server['request_uri']);
-        if (! $filename) {
+        if ($filename === null) {
             return null;
         }
 

--- a/src/StaticMappedResourceHandler.php
+++ b/src/StaticMappedResourceHandler.php
@@ -20,22 +20,16 @@ class StaticMappedResourceHandler implements StaticResourceHandlerInterface
     use ValidateMiddlewareTrait;
 
     /**
-     * Middleware to execute when serving a static resource.
-     *
-     * @var StaticResourceHandler\MiddlewareInterface[]
-     */
-    private array $middleware = [];
-
-    /**
+     * @param StaticResourceHandler\MiddlewareInterface[] $middleware Middleware to execute
+     *     when serving a static resource.
      * @throws Exception\InvalidStaticResourceMiddlewareException For any
      *     non-callable middleware encountered.
      */
     public function __construct(
         private FileLocationRepositoryInterface $fileLocationRepo,
-        array $middleware = []
+        private array $middleware = []
     ) {
         $this->validateMiddleware($middleware);
-        $this->middleware = $middleware;
     }
 
     public function processStaticResource(

--- a/src/StaticResourceHandler/CacheControlMiddleware.php
+++ b/src/StaticResourceHandler/CacheControlMiddleware.php
@@ -54,7 +54,7 @@ class CacheControlMiddleware implements MiddlewareInterface
     {
         $response     = $next($request, $filename);
         $cacheControl = $this->getCacheControlForPath($request->server['request_uri']);
-        if ($cacheControl) {
+        if ($cacheControl !== null) {
             $response->addHeader('Cache-Control', $cacheControl);
         }
 

--- a/src/StaticResourceHandler/ClearStatCacheMiddleware.php
+++ b/src/StaticResourceHandler/ClearStatCacheMiddleware.php
@@ -26,7 +26,7 @@ class ClearStatCacheMiddleware implements MiddlewareInterface
          * the stat cache should ALWAYS be cleared. Otherwise, the value is the number
          * of seconds between clear operations.
          */
-        private int $interval
+        private readonly int $interval
     ) {
     }
 

--- a/src/StaticResourceHandler/ETagMiddleware.php
+++ b/src/StaticResourceHandler/ETagMiddleware.php
@@ -100,10 +100,12 @@ class ETagMiddleware implements MiddlewareInterface
         string $filename,
         StaticResourceResponse $response
     ): StaticResourceResponse {
-        $lastModified = filemtime($filename) ?: 0;
+        $fileTime     = filemtime($filename);
+        $lastModified = $fileTime !== false ? $fileTime : 0;
         switch ($this->etagValidationType) {
             case self::ETAG_VALIDATION_WEAK:
-                $filesize = filesize($filename) ?: 0;
+                $size     = filesize($filename);
+                $filesize = $size !== false ? $size : 0;
                 if (! $lastModified || ! $filesize) {
                     return $response;
                 }
@@ -122,7 +124,7 @@ class ETagMiddleware implements MiddlewareInterface
         // Determine if ETag the client expects matches calculated ETag
         $ifMatch     = $request->header['if-match'] ?? '';
         $ifNoneMatch = $request->header['if-none-match'] ?? '';
-        $clientEtags = explode(',', $ifMatch ?: $ifNoneMatch);
+        $clientEtags = explode(',', $ifMatch !== '' ? $ifMatch : $ifNoneMatch);
         array_walk($clientEtags, 'trim');
 
         if (in_array($etag, $clientEtags, true)) {

--- a/src/StaticResourceHandler/FileLocationRepository.php
+++ b/src/StaticResourceHandler/FileLocationRepository.php
@@ -130,7 +130,7 @@ class FileLocationRepository implements FileLocationRepositoryInterface
         foreach ($this->mappedDocRoots as $prefix => $directories) {
             foreach ($directories as $directory) {
                 if (stripos($filename, (string) $prefix) === 0) {
-                    $mappedFileName = $directory . substr($filename, strlen($prefix));
+                    $mappedFileName = $directory . substr($filename, strlen((string) $prefix));
                     if (file_exists($mappedFileName)) {
                         return $mappedFileName;
                     }

--- a/src/StaticResourceHandler/GzipMiddleware.php
+++ b/src/StaticResourceHandler/GzipMiddleware.php
@@ -38,7 +38,7 @@ class GzipMiddleware implements MiddlewareInterface
         ZLIB_ENCODING_GZIP    => 'gzip',
     ];
 
-    private int $compressionLevel;
+    private readonly int $compressionLevel;
 
     /**
      * @param int $compressionLevel Compression level to use. Values less than
@@ -123,7 +123,7 @@ class GzipMiddleware implements MiddlewareInterface
      */
     private function getCompressionEncoding(Request $request): ?int
     {
-        foreach (explode(',', $request->header['accept-encoding']) as $acceptEncoding) {
+        foreach (explode(',', (string) $request->header['accept-encoding']) as $acceptEncoding) {
             $acceptEncoding = trim($acceptEncoding);
             if ('gzip' === $acceptEncoding) {
                 return ZLIB_ENCODING_GZIP;

--- a/src/StaticResourceHandler/LastModifiedMiddleware.php
+++ b/src/StaticResourceHandler/LastModifiedMiddleware.php
@@ -41,7 +41,8 @@ class LastModifiedMiddleware implements MiddlewareInterface
             return $response;
         }
 
-        $lastModified = filemtime($filename) ?: 0;
+        $fileTime     = filemtime($filename);
+        $lastModified = $fileTime !== false ? $fileTime : 0;
         $lastModified = new DateTimeImmutable('@' . $lastModified, new DateTimeZone('GMT'));
 
         $formattedLastModified = IntlDateFormatter::formatObject(

--- a/src/StaticResourceHandler/LastModifiedMiddleware.php
+++ b/src/StaticResourceHandler/LastModifiedMiddleware.php
@@ -20,17 +20,13 @@ class LastModifiedMiddleware implements MiddlewareInterface
 {
     use ValidateRegexTrait;
 
-    /** @var string[] */
-    private array $lastModifiedDirectives = [];
-
     /**
      * @param string[] $lastModifiedDirectives Array of regexex indicating
      *     paths/file types that should emit a Last-Modified header.
      */
-    public function __construct(array $lastModifiedDirectives = [])
+    public function __construct(private array $lastModifiedDirectives = [])
     {
         $this->validateRegexList($lastModifiedDirectives, 'Last-Modified');
-        $this->lastModifiedDirectives = $lastModifiedDirectives;
     }
 
     public function __invoke(Request $request, string $filename, callable $next): StaticResourceResponse

--- a/src/StaticResourceHandler/StaticResourceResponse.php
+++ b/src/StaticResourceHandler/StaticResourceResponse.php
@@ -41,7 +41,7 @@ class StaticResourceResponse
         ?callable $responseContentCallback = null
     ) {
         $this->responseContentCallback = $responseContentCallback
-            ?: function (SwooleHttpResponse $response, string $filename): void {
+            ?? function (SwooleHttpResponse $response, string $filename): void {
                 $this->contentLength = filesize($filename);
                 $response->header('Content-Length', (string) $this->contentLength, true);
                 $response->sendfile($filename);

--- a/src/StaticResourceHandler/ValidateRegexTrait.php
+++ b/src/StaticResourceHandler/ValidateRegexTrait.php
@@ -22,7 +22,7 @@ trait ValidateRegexTrait
 {
     private function isValidRegex(string $regex): bool
     {
-        set_error_handler(static fn($errno) => $errno === E_WARNING);
+        set_error_handler(static fn($errno): bool => $errno === E_WARNING);
         $isValid = preg_match($regex, '') !== false;
         restore_error_handler();
         return $isValid;

--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -105,12 +105,15 @@ class SwooleEmitter implements EmitterInterface
         foreach (SetCookies::fromResponse($response)->getAll() as $cookie) {
             $sameSite = $cookie->getSameSite() !== null ? substr($cookie->getSameSite()->asString(), 9) : '';
 
+            $path   = $cookie->getPath();
+            $domain = $cookie->getDomain();
+
             $this->swooleResponse->cookie(
                 $cookie->getName(),
                 (string) $cookie->getValue(),
                 $cookie->getExpires(),
-                $cookie->getPath() ?: '/',
-                $cookie->getDomain() ?: '',
+                $path ?? '/',
+                $domain ?? '',
                 $cookie->getSecure(),
                 $cookie->getHttpOnly(),
                 $sameSite

--- a/src/SwooleStream.php
+++ b/src/SwooleStream.php
@@ -39,7 +39,7 @@ final class SwooleStream implements StreamInterface, Stringable
         /**
          * Swoole request containing the body contents.
          */
-        private SwooleHttpRequest $request
+        private readonly SwooleHttpRequest $request
     ) {
     }
 
@@ -90,7 +90,7 @@ final class SwooleStream implements StreamInterface, Stringable
             if ($this->body === null) {
                 $this->initRawContent();
             }
-            $this->bodySize = strlen($this->body);
+            $this->bodySize = strlen((string) $this->body);
         }
 
         return $this->bodySize;
@@ -119,7 +119,7 @@ final class SwooleStream implements StreamInterface, Stringable
         if ($this->body === null) {
             $this->initRawContent();
         }
-        $result = substr($this->body, $this->index, $length);
+        $result = substr((string) $this->body, $this->index, $length);
 
         // Reset index based on legnth; should not be > EOF position.
         $size        = $this->getSize();
@@ -206,12 +206,11 @@ final class SwooleStream implements StreamInterface, Stringable
 
     // phpcs:enable
     /**
-     * @param string $key
      * @return null|array
      */
-    public function getMetadata($key = null): ?array
+    public function getMetadata(?string $key = null): ?array
     {
-        return $key ? null : [];
+        return $key !== null ? null : [];
     }
 
     public function detach(): SwooleHttpRequest
@@ -229,10 +228,12 @@ final class SwooleStream implements StreamInterface, Stringable
      */
     private function initRawContent(): void
     {
-        if ($this->body) {
+        if ($this->body !== null) {
             return;
         }
 
-        $this->body = $this->request->rawContent() ?: '';
+        $raw = $this->request->rawContent();
+
+        $this->body = $raw === false ? '' : $raw;
     }
 }

--- a/src/Task/DeferredListener.php
+++ b/src/Task/DeferredListener.php
@@ -27,7 +27,7 @@ final class DeferredListener
     /** @var callable */
     private $listener;
 
-    public function __construct(private SwooleHttpServer $server, callable $listener)
+    public function __construct(private readonly SwooleHttpServer $server, callable $listener)
     {
         $this->listener = $listener;
     }

--- a/src/Task/DeferredServiceListener.php
+++ b/src/Task/DeferredServiceListener.php
@@ -22,8 +22,11 @@ final class DeferredServiceListener
     /** @var callable */
     private $listener;
 
-    public function __construct(private SwooleHttpServer $server, callable $listener, private string $serviceName)
-    {
+    public function __construct(
+        private readonly SwooleHttpServer $server,
+        callable $listener,
+        private readonly string $serviceName
+    ) {
         $this->listener = $listener;
     }
 

--- a/src/Task/ServiceBasedTask.php
+++ b/src/Task/ServiceBasedTask.php
@@ -26,21 +26,18 @@ use Webmozart\Assert\Assert;
  */
 final class ServiceBasedTask implements TaskInterface
 {
-    private array $payload;
+    private readonly array $payload;
 
     /**
      * @param array $payload Array of arguments for the $serviceName.
      * @psalm-param list<mixed> $payload
      */
-    public function __construct(private string $serviceName, ...$payload)
+    public function __construct(private readonly string $serviceName, ...$payload)
     {
         $this->payload = $payload;
     }
 
-    /**
-     * @return mixed
-     */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): mixed
     {
         $deferred = $container->get($this->serviceName);
         Assert::isCallable($deferred);
@@ -55,11 +52,9 @@ final class ServiceBasedTask implements TaskInterface
     /**
      * Cannot add return types to internal interface methods in implementing
      * classes.
-     *
-     * @return array
      */
     #[ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'handler'   => $this->serviceName,

--- a/src/Task/Task.php
+++ b/src/Task/Task.php
@@ -36,7 +36,7 @@ final class Task implements TaskInterface
     private $handler;
 
     /** @psalm-var list<mixed> */
-    private array $payload;
+    private readonly array $payload;
 
     /**
      * @param array $payload Array of arguments for the $serviceName.
@@ -50,10 +50,8 @@ final class Task implements TaskInterface
 
     /**
      * Container argument ignored in this implementation.
-     *
-     * @return mixed
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container): mixed
     {
         return ($this->handler)(...$this->payload);
     }
@@ -61,11 +59,9 @@ final class Task implements TaskInterface
     /**
      * Cannot add return types to internal interface methods in implementing
      * classes.
-     *
-     * @return array
      */
     #[ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'handler'   => $this->serializeHandler($this->handler),

--- a/src/Task/TaskEventDispatchListener.php
+++ b/src/Task/TaskEventDispatchListener.php
@@ -19,7 +19,7 @@ use function sprintf;
 /**
  * Listener that dispatches TaskEvent `$data` arguments as events.
  */
-final class TaskEventDispatchListener
+final readonly class TaskEventDispatchListener
 {
     public function __construct(private EventDispatcherInterface $dispatcher, private ?LoggerInterface $logger = null)
     {

--- a/src/Task/TaskInterface.php
+++ b/src/Task/TaskInterface.php
@@ -26,8 +26,6 @@ interface TaskInterface extends JsonSerializable
 {
     /**
      * Tasks are invokable; implement this method to do the work of the task.
-     *
-     * @return mixed
      */
-    public function __invoke(ContainerInterface $container);
+    public function __invoke(ContainerInterface $container): mixed;
 }

--- a/src/Task/TaskInvokerListener.php
+++ b/src/Task/TaskInvokerListener.php
@@ -22,7 +22,7 @@ use const JSON_THROW_ON_ERROR;
 /**
  * Derived from phly/phly-swoole-taskworker, @copyright Copyright (c) Matthew Weier O'Phinney
  */
-final class TaskInvokerListener
+final readonly class TaskInvokerListener
 {
     public function __construct(private ContainerInterface $container, private ?LoggerInterface $logger = null)
     {

--- a/test/AttributeAssertionTrait.php
+++ b/test/AttributeAssertionTrait.php
@@ -23,7 +23,7 @@ trait AttributeAssertionTrait
     /**
      * @param object $instance Instance composing attribute to test
      */
-    public static function assertAttributeEmpty(string $attributeName, $instance, string $message = ''): void
+    public static function assertAttributeEmpty(string $attributeName, object $instance, string $message = ''): void
     {
         $r = new ReflectionProperty($instance, $attributeName);
         Assert::assertEmpty($r->getValue($instance), $message);
@@ -36,12 +36,8 @@ trait AttributeAssertionTrait
     public static function assertAttributeEquals(
         mixed $expected,
         string $attributeName,
-        $instance,
+        object $instance,
         string $message = '',
-        float $delta = 0,
-        int $maxDepth = 10,
-        bool $canonicalize = false,
-        bool $ignoreCase = false
     ): void {
         $r = new ReflectionProperty($instance, $attributeName);
         Assert::assertEquals($expected, $r->getValue($instance), $message);
@@ -54,7 +50,7 @@ trait AttributeAssertionTrait
     public static function assertAttributeInstanceOf(
         mixed $expected,
         string $attributeName,
-        $instance,
+        object $instance,
         string $message = ''
     ): void {
         $r = new ReflectionProperty($instance, $attributeName);
@@ -68,7 +64,7 @@ trait AttributeAssertionTrait
     public static function assertAttributeSame(
         mixed $expected,
         string $attributeName,
-        $instance,
+        object $instance,
         string $message = ''
     ): void {
         $r = new ReflectionProperty($instance, $attributeName);

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -31,14 +31,9 @@ final class ReloadCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
-    /** @psalm-var MockObject&InputInterface */
-    private InputInterface|MockObject $input;
+    private InputInterface&MockObject $input;
 
-    /**
-     * @var OutputInterface|MockObject
-     * @psalm-var MockObject&OutputInterface
-     */
-    private $output;
+    private OutputInterface&MockObject $output;
 
     protected function setUp(): void
     {
@@ -143,7 +138,7 @@ final class ReloadCommandTest extends TestCase
         $stopCommand
             ->method('run')
             ->with(
-                $this->callback(static fn(ArrayInput $arg) => 'stop' === (string) $arg),
+                $this->callback(static fn(ArrayInput $arg): bool => 'stop' === (string) $arg),
                 $this->output
             )
             ->willReturn(1);
@@ -181,7 +176,7 @@ final class ReloadCommandTest extends TestCase
         $stopCommand
             ->method('run')
             ->with(
-                $this->callback(static fn(ArrayInput $arg) => 'stop' === (string) $arg),
+                $this->callback(static fn(ArrayInput $arg): bool => 'stop' === (string) $arg),
                 $this->output
             )
             ->willReturn(0);
@@ -190,7 +185,9 @@ final class ReloadCommandTest extends TestCase
         $startCommand
             ->method('run')
             ->with(
-                $this->callback(static fn(ArrayInput $arg) => 'start --daemonize=1 --num-workers=5' === (string) $arg),
+                $this->callback(
+                    static fn(ArrayInput $arg): bool => 'start --daemonize=1 --num-workers=5' === (string) $arg
+                ),
                 $this->output
             )
             ->willReturn(1);
@@ -248,7 +245,7 @@ final class ReloadCommandTest extends TestCase
         $stopCommand
             ->method('run')
             ->with(
-                $this->callback(static fn(ArrayInput $arg) => 'stop' === (string) $arg),
+                $this->callback(static fn(ArrayInput $arg): bool => 'stop' === (string) $arg),
                 $this->output
             )
             ->willReturn(0);
@@ -258,7 +255,7 @@ final class ReloadCommandTest extends TestCase
             ->method('run')
             ->with(
                 $this->callback(
-                    static fn(ArrayInput $arg)
+                    static fn(ArrayInput $arg): bool
                         => 'start --daemonize=1 --num-workers=5 --num-task-workers=2' === (string) $arg
                 ),
                 $this->output

--- a/test/Command/StartCommandTest.php
+++ b/test/Command/StartCommandTest.php
@@ -37,22 +37,15 @@ final class StartCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
-    /** @psalm-var MockObject&ContainerInterface */
-    private ContainerInterface|MockObject $container;
+    private ContainerInterface&MockObject $container;
 
-    /** @psalm-var MockObject&InputInterface */
-    private InputInterface|MockObject $input;
+    private InputInterface&MockObject $input;
 
     private string $originalIncludePath;
 
-    /**
-     * @var OutputInterface|MockObject
-     * @psalm-var MockObject&OutputInterface
-     */
-    private $output;
+    private OutputInterface&MockObject $output;
 
-    /** @psalm-var MockObject&PidManager */
-    private PidManager|MockObject $pidManager;
+    private PidManager&MockObject $pidManager;
 
     protected function setUp(): void
     {
@@ -227,7 +220,7 @@ final class StartCommandTest extends TestCase
         $httpServer
             ->expects($this->once())
             ->method('set')
-            ->with($this->callback(static fn(array $options) => array_key_exists('daemonize', $options)
+            ->with($this->callback(static fn(array $options): bool => array_key_exists('daemonize', $options)
                 && array_key_exists('worker_num', $options)
                 && array_key_exists('task_worker_num', $options)
                 && true === $options['daemonize']

--- a/test/Command/StatusCommandTest.php
+++ b/test/Command/StatusCommandTest.php
@@ -24,17 +24,11 @@ final class StatusCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
-    /** @psalm-var MockObject&InputInterface */
-    private InputInterface|MockObject $input;
+    private InputInterface&MockObject $input;
 
-    /**
-     * @var OutputInterface|MockObject
-     * @psalm-var MockObject&OutputInterface
-     */
-    private $output;
+    private OutputInterface&MockObject $output;
 
-    /** @psalm-var MockObject&PidManager */
-    private PidManager|MockObject $pidManager;
+    private PidManager&MockObject $pidManager;
 
     protected function setUp(): void
     {

--- a/test/Command/StopCommandTest.php
+++ b/test/Command/StopCommandTest.php
@@ -25,17 +25,11 @@ final class StopCommandTest extends TestCase
     use AttributeAssertionTrait;
     use ReflectMethodTrait;
 
-    /** @psalm-var MockObject&InputInterface */
-    private InputInterface|MockObject $input;
+    private InputInterface&MockObject $input;
 
-    /**
-     * @var OutputInterface|MockObject
-     * @psalm-var MockObject&OutputInterface
-     */
-    private $output;
+    private OutputInterface&MockObject $output;
 
-    /** @psalm-var MockObject&PidManager */
-    private PidManager|MockObject $pidManager;
+    private PidManager&MockObject $pidManager;
 
     protected function setUp(): void
     {

--- a/test/Command/TestAsset/config/pipeline.php
+++ b/test/Command/TestAsset/config/pipeline.php
@@ -8,5 +8,5 @@ use Mezzio\Application;
 use Mezzio\MiddlewareFactory;
 use Psr\Container\ContainerInterface;
 
-return static function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) {
+return static function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {
 };

--- a/test/Command/TestAsset/config/routes.php
+++ b/test/Command/TestAsset/config/routes.php
@@ -8,5 +8,5 @@ use Mezzio\Application;
 use Mezzio\MiddlewareFactory;
 use Psr\Container\ContainerInterface;
 
-return static function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) {
+return static function (Application $app, MiddlewareFactory $factory, ContainerInterface $container): void {
 };

--- a/test/ConsecutiveConstraint.php
+++ b/test/ConsecutiveConstraint.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Constraint\Constraint;
 final class ConsecutiveConstraint extends Constraint
 {
     /** @var Iterator<array-key, Constraint> */
-    private Iterator $constraints;
+    private readonly Iterator $constraints;
     private bool $initial = true;
 
     /**

--- a/test/Event/EventDispatcherTest.php
+++ b/test/Event/EventDispatcherTest.php
@@ -17,11 +17,7 @@ use Psr\EventDispatcher\StoppableEventInterface;
 
 final class EventDispatcherTest extends TestCase
 {
-    /**
-     * @var ListenerProviderInterface|MockObject
-     * @psalm-var ListenerProviderInterface&MockObject
-     */
-    private ListenerProviderInterface $provider;
+    private ListenerProviderInterface&MockObject $provider;
 
     private EventDispatcher $dispatcher;
 
@@ -83,11 +79,8 @@ final class EventDispatcherTest extends TestCase
         };
 
         $event = new class ($spy) implements StoppableEventInterface {
-            private object $spy;
-
-            public function __construct(object $spy)
+            public function __construct(private readonly object $spy)
             {
-                $this->spy = $spy;
             }
 
             public function isPropagationStopped(): bool

--- a/test/Event/RequestHandlerRequestListenerTest.php
+++ b/test/Event/RequestHandlerRequestListenerTest.php
@@ -24,30 +24,23 @@ use Throwable;
 
 final class RequestHandlerRequestListenerTest extends TestCase
 {
-    /** @psalm-var SwooleEmitter&MockObject */
-    private SwooleEmitter $emitter;
+    private SwooleEmitter&MockObject $emitter;
 
-    /** @psalm-var ResponseInterface&MockObject */
-    private ResponseInterface $errorResponse;
+    private ResponseInterface&MockObject $errorResponse;
 
     private ?Throwable $exceptionToThrowOnRequestGeneration = null;
 
     private RequestHandlerRequestListener $listener;
 
-    /** @psalm-var AccessLogInterface&MockObject */
-    private AccessLogInterface $logger;
+    private AccessLogInterface&MockObject $logger;
 
-    /** @psalm-var ServerRequestInterface&MockObject */
-    private ServerRequestInterface $request;
+    private ServerRequestInterface&MockObject $request;
 
-    /** @psalm-var RequestHandlerInterface&MockObject */
-    private RequestHandlerInterface $requestHandler;
+    private RequestHandlerInterface&MockObject $requestHandler;
 
-    /** @psalm-var SwooleHttpRequest&MockObject */
-    private SwooleHttpRequest $swooleRequest;
+    private SwooleHttpRequest&MockObject $swooleRequest;
 
-    /** @psalm-var SwooleHttpResponse&MockObject */
-    private SwooleHttpResponse $swooleResponse;
+    private SwooleHttpResponse&MockObject $swooleResponse;
 
     protected function setUp(): void
     {

--- a/test/Event/StaticResourceRequestListenerTest.php
+++ b/test/Event/StaticResourceRequestListenerTest.php
@@ -20,17 +20,16 @@ use Swoole\Http\Response as SwooleHttpResponse;
 
 final class StaticResourceRequestListenerTest extends TestCase
 {
-    /** @psalm-var StaticResourceHandlerInterface&MockObject */
-    private StaticResourceHandlerInterface $handler;
+    private StaticResourceHandlerInterface&MockObject $handler;
 
     private StaticResourceRequestListener $listener;
 
-    /** @psalm-var AccessLogInterface&MockObject */
-    private AccessLogInterface $logger;
+    /** @psalm-var  */
+    private AccessLogInterface&MockObject $logger;
 
-    private SwooleHttpRequest $swooleRequest;
+    private SwooleHttpRequest&MockObject $swooleRequest;
 
-    private SwooleHttpResponse $swooleResponse;
+    private SwooleHttpResponse&MockObject $swooleResponse;
 
     protected function setUp(): void
     {

--- a/test/HttpServerFactoryTest.php
+++ b/test/HttpServerFactoryTest.php
@@ -43,8 +43,7 @@ use const SWOOLE_UNIX_STREAM;
 
 final class HttpServerFactoryTest extends TestCase
 {
-    /** @psalm-var MockObject&ContainerInterface */
-    private ContainerInterface|MockObject $container;
+    private ContainerInterface&MockObject $container;
 
     protected function setUp(): void
     {
@@ -103,7 +102,7 @@ final class HttpServerFactoryTest extends TestCase
         $data = $process->read();
         Process::wait(true);
 
-        $result = json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+        $result = json_decode((string) $data, true, 512, JSON_THROW_ON_ERROR);
         $this->assertSame([
             'host' => '0.0.0.0',
             'port' => 8081,
@@ -234,7 +233,7 @@ final class HttpServerFactoryTest extends TestCase
         });
         $process->start();
 
-        $setOptions = json_decode($process->read(), true, 512, JSON_THROW_ON_ERROR);
+        $setOptions = json_decode((string) $process->read(), true, 512, JSON_THROW_ON_ERROR);
         Process::wait(true);
         $this->assertSame($serverOptions, $setOptions);
     }

--- a/test/HttpServerFactoryTest.php
+++ b/test/HttpServerFactoryTest.php
@@ -269,10 +269,9 @@ final class HttpServerFactoryTest extends TestCase
 
     /**
      * @dataProvider validSocketTypes
-     * @param int $socketType
      * @psalm-param array<string, string> $additionalOptions
      */
-    public function testServerCanBeStartedForKnownSocketTypeCombinations($socketType, array $additionalOptions): void
+    public function testServerCanBeStartedForKnownSocketTypeCombinations(int $socketType, array $additionalOptions): void
     {
         $this->container->method('get')->with('config')->willReturn([
             'mezzio-swoole' => [

--- a/test/Log/AccessLogDataMapTest.php
+++ b/test/Log/AccessLogDataMapTest.php
@@ -21,11 +21,9 @@ use function date_default_timezone_get;
 
 final class AccessLogDataMapTest extends TestCase
 {
-    /** @psalm-var MockObject&SwooleHttpRequest */
-    private SwooleHttpRequest|MockObject $request;
+    private SwooleHttpRequest&MockObject $request;
 
-    /** @psalm-var MockObject&ResponseInterface */
-    private ResponseInterface|MockObject $response;
+    private ResponseInterface&MockObject $response;
 
     protected function setUp(): void
     {

--- a/test/Log/AccessLogFactoryTest.php
+++ b/test/Log/AccessLogFactoryTest.php
@@ -25,14 +25,9 @@ final class AccessLogFactoryTest extends TestCase
     use AttributeAssertionTrait;
     use LoggerFactoryHelperTrait;
 
-    /**
-     * @var LoggerInterface|MockObject
-     * @psalm-var LoggerInterface&MockObject
-     */
-    private $logger;
+    private LoggerInterface&MockObject $logger;
 
-    /** @psalm-var AccessLogFormatterInterface&MockObject */
-    private AccessLogFormatterInterface|MockObject $formatter;
+    private AccessLogFormatterInterface&MockObject $formatter;
 
     protected function setUp(): void
     {

--- a/test/Log/Psr3AccessLogDecoratorTest.php
+++ b/test/Log/Psr3AccessLogDecoratorTest.php
@@ -26,20 +26,15 @@ final class Psr3AccessLogDecoratorTest extends TestCase
 {
     use AttributeAssertionTrait;
 
-    /** @psalm-var MockObject&LoggerInterface */
-    private LoggerInterface|MockObject $psr3Logger;
+    private LoggerInterface&MockObject $psr3Logger;
 
-    /** @psalm-var MockObject&AccessLogFormatterInterface */
-    private AccessLogFormatterInterface|MockObject $formatter;
+    private AccessLogFormatterInterface&MockObject $formatter;
 
-    /** @psalm-var MockObject&Request */
-    private Request|MockObject $request;
+    private Request&MockObject $request;
 
-    /** @psalm-var MockObject&Psr7Response */
-    private Psr7Response|MockObject $psr7Response;
+    private Psr7Response&MockObject $psr7Response;
 
-    /** @psalm-var MockObject&StaticResourceResponse */
-    private StaticResourceResponse|MockObject $staticResponse;
+    private StaticResourceResponse&MockObject $staticResponse;
 
     protected function setUp(): void
     {
@@ -50,8 +45,7 @@ final class Psr3AccessLogDecoratorTest extends TestCase
         $this->staticResponse = $this->createMock(StaticResourceResponse::class);
     }
 
-    /** @return mixed */
-    private function getPropertyForInstance(string $property, object $instance)
+    private function getPropertyForInstance(string $property, object $instance): mixed
     {
         $r = new ReflectionProperty($instance, $property);
         return $r->getValue($instance);
@@ -118,7 +112,7 @@ final class Psr3AccessLogDecoratorTest extends TestCase
         $this->formatter
             ->method('format')
             ->with($this->callback(
-                fn (AccessLogDataMap $mapper) =>
+                fn (AccessLogDataMap $mapper): bool =>
                 $this->request === $this->getPropertyForInstance('request', $mapper) &&
                     $this->staticResponse === $this->getPropertyForInstance('staticResource', $mapper) &&
                     false === $this->getPropertyForInstance('useHostnameLookups', $mapper)
@@ -149,7 +143,7 @@ final class Psr3AccessLogDecoratorTest extends TestCase
         $this->formatter
             ->method('format')
             ->with($this->callback(
-                fn (AccessLogDataMap $mapper) =>
+                fn (AccessLogDataMap $mapper): bool =>
                 $this->request === $this->getPropertyForInstance('request', $mapper) &&
                     $this->psr7Response === $this->getPropertyForInstance('psrResponse', $mapper) &&
                     false === $this->getPropertyForInstance('useHostnameLookups', $mapper)

--- a/test/Log/SwooleLoggerFactoryTest.php
+++ b/test/Log/SwooleLoggerFactoryTest.php
@@ -18,11 +18,7 @@ final class SwooleLoggerFactoryTest extends TestCase
 {
     use LoggerFactoryHelperTrait;
 
-    /**
-     * @var LoggerInterface|MockObject
-     * @psalm-var LoggerInterface&MockObject
-     */
-    private $logger;
+    private LoggerInterface&MockObject $logger;
 
     protected function setUp(): void
     {

--- a/test/PidManagerFactoryTest.php
+++ b/test/PidManagerFactoryTest.php
@@ -15,8 +15,7 @@ use Psr\Container\ContainerInterface;
 
 final class PidManagerFactoryTest extends TestCase
 {
-    /** @psalm-var MockObject&ContainerInterface */
-    private ContainerInterface|MockObject $container;
+    private ContainerInterface&MockObject $container;
 
     private PidManagerFactory $pidManagerFactory;
 

--- a/test/StaticMappedResourceHandlerFactoryTest.php
+++ b/test/StaticMappedResourceHandlerFactoryTest.php
@@ -32,11 +32,9 @@ final class StaticMappedResourceHandlerFactoryTest extends TestCase
 {
     use AttributeAssertionTrait;
 
-    /** @psalm-var MockObject&ContainerInterface */
-    private ContainerInterface|MockObject $container;
+    private ContainerInterface&MockObject $container;
 
-    /** @psalm-var MockObject&FileLocationRepositoryInterface */
-    private FileLocationRepositoryInterface|MockObject $fileLocRepo;
+    private FileLocationRepositoryInterface&MockObject $fileLocRepo;
 
     protected function setUp(): void
     {

--- a/test/StaticMappedResourceHandlerTest.php
+++ b/test/StaticMappedResourceHandlerTest.php
@@ -44,6 +44,7 @@ final class StaticMappedResourceHandlerTest extends TestCase
     public function testConstructorRaisesExceptionForInvalidMiddlewareValue(): void
     {
         $this->expectException(Exception\InvalidStaticResourceMiddlewareException::class);
+        /** @psalm-suppress InvalidArgument */
         new StaticMappedResourceHandler($this->fileLocRepo, [$this]);
     }
 

--- a/test/StaticMappedResourceHandlerTest.php
+++ b/test/StaticMappedResourceHandlerTest.php
@@ -20,23 +20,11 @@ use Swoole\Http\Response as SwooleHttpResponse;
 
 final class StaticMappedResourceHandlerTest extends TestCase
 {
-    /**
-     * @var FileLocationRepositoryInterface|MockObject
-     * @psalm-var MockObject&FileLocationRepositoryInterface
-     */
-    private $fileLocRepo;
+    private FileLocationRepositoryInterface&MockObject $fileLocRepo;
 
-    /**
-     * @var SwooleHttpRequest|MockObject
-     * @psalm-var MockObject&SwooleHttpRequest
-     */
-    private $request;
+    private SwooleHttpRequest&MockObject $request;
 
-    /**
-     * @var SwooleHttpResponse|MockObject
-     * @psalm-var MockObject&SwooleHttpResponse
-     */
-    private $response;
+    private SwooleHttpResponse&MockObject $response;
 
     /** @psalm-var non-empty-string */
     private string $uri;
@@ -95,11 +83,8 @@ final class StaticMappedResourceHandlerTest extends TestCase
             ->with($this->response, $this->fullPath);
 
         $middleware = new class ($expectedResponse) implements MiddlewareInterface {
-            private StaticResourceResponse $response;
-
-            public function __construct(StaticResourceResponse $response)
+            public function __construct(private readonly StaticResourceResponse $response)
             {
-                $this->response = $response;
             }
 
             public function __invoke(
@@ -130,11 +115,8 @@ final class StaticMappedResourceHandlerTest extends TestCase
         $expectedResponse->method('isFailure')->willReturn(true);
 
         $middleware = new class ($expectedResponse) implements MiddlewareInterface {
-            private StaticResourceResponse $response;
-
-            public function __construct(StaticResourceResponse $response)
+            public function __construct(private readonly StaticResourceResponse $response)
             {
-                $this->response = $response;
             }
 
             public function __invoke(

--- a/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
+++ b/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
@@ -21,8 +21,7 @@ final class ContentTypeFilterMiddlewareTest extends TestCase
     use AssertResponseTrait;
     use AttributeAssertionTrait;
 
-    /** @psalm-var MockObject&Request */
-    private Request|MockObject $request;
+    private Request&MockObject $request;
 
     protected function setUp(): void
     {
@@ -50,7 +49,7 @@ final class ContentTypeFilterMiddlewareTest extends TestCase
 
     public function testMiddlewareReturnsFailureResponseIfFileNotAllowedByTypeMap(): void
     {
-        $next       = static function (Request $request, string $filename): void {
+        $next       = static function (Request $request, string $filename): never {
             TestCase::fail('Should not have invoked next middleware');
         };
         $middleware = new ContentTypeFilterMiddleware([

--- a/test/StaticResourceHandler/ETagMiddlewareTest.php
+++ b/test/StaticResourceHandler/ETagMiddlewareTest.php
@@ -30,8 +30,7 @@ final class ETagMiddlewareTest extends TestCase
     /** @var callable */
     private $next;
 
-    /** @psalm-var MockObject&Request */
-    private Request|MockObject $request;
+    private Request&MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
+++ b/test/StaticResourceHandler/FileLocationRepositoryFactoryTest.php
@@ -22,8 +22,7 @@ use function time;
 
 final class FileLocationRepositoryFactoryTest extends TestCase
 {
-    /** @psalm-var MockObject&ContainerInterface */
-    private ContainerInterface|MockObject $mockContainer;
+    private ContainerInterface&MockObject $mockContainer;
 
     private FileLocationRepositoryFactory $fileLocRepoFactory;
 

--- a/test/StaticResourceHandler/GzipMiddlewareTest.php
+++ b/test/StaticResourceHandler/GzipMiddlewareTest.php
@@ -30,11 +30,9 @@ final class GzipMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /** @psalm-var StaticResourceResponse&MockObject */
-    private StaticResourceResponse|MockObject $staticResponse;
+    private StaticResourceResponse&MockObject $staticResponse;
 
-    /** @psalm-var SwooleHttpRequest&MockObject */
-    private SwooleHttpRequest|MockObject $swooleRequest;
+    private SwooleHttpRequest&MockObject $swooleRequest;
 
     /** @var callable */
     private $next;

--- a/test/StaticResourceHandler/HeadMiddlewareTest.php
+++ b/test/StaticResourceHandler/HeadMiddlewareTest.php
@@ -19,8 +19,7 @@ final class HeadMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /** @psalm-var MockObject&Request */
-    private Request|MockObject $request;
+    private Request&MockObject $request;
 
     /** @var callable */
     private $next;

--- a/test/StaticResourceHandler/IntegrationMappedTest.php
+++ b/test/StaticResourceHandler/IntegrationMappedTest.php
@@ -38,8 +38,7 @@ final class IntegrationMappedTest extends TestCase
 {
     use FormatTimestampTrait;
 
-    /** @psalm-var MockObject&FileLocationRepositoryInterface */
-    private FileLocationRepositoryInterface|MockObject $mockFileLocRepo;
+    private FileLocationRepositoryInterface&MockObject $mockFileLocRepo;
 
     /** @psalm-var non-empty-string */
     private string $assetPath;

--- a/test/StaticResourceHandler/LastModifiedMiddlewareTest.php
+++ b/test/StaticResourceHandler/LastModifiedMiddlewareTest.php
@@ -27,8 +27,7 @@ final class LastModifiedMiddlewareTest extends TestCase
     /** @var callable */
     private $next;
 
-    /** @psalm-var MockObject&Request */
-    private Request|MockObject $request;
+    private Request&MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php
+++ b/test/StaticResourceHandler/MethodNotAllowedMiddlewareTest.php
@@ -19,8 +19,7 @@ final class MethodNotAllowedMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /** @psalm-var MockObject&Request */
-    private Request|MockObject $request;
+    private Request&MockObject $request;
 
     protected function setUp(): void
     {
@@ -79,7 +78,7 @@ final class MethodNotAllowedMiddlewareTest extends TestCase
         $this->request->server = [
             'request_method' => $method,
         ];
-        $next                  = function (): void {
+        $next                  = function (): never {
             $this->fail('Should not have reached next()');
         };
         $middleware            = new MethodNotAllowedMiddleware();

--- a/test/StaticResourceHandler/MiddlewareQueueTest.php
+++ b/test/StaticResourceHandler/MiddlewareQueueTest.php
@@ -20,8 +20,7 @@ final class MiddlewareQueueTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /** @psalm-var MockObject&Request */
-    private Request|MockObject $request;
+    private Request&MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/OptionsMiddlewareTest.php
+++ b/test/StaticResourceHandler/OptionsMiddlewareTest.php
@@ -19,8 +19,7 @@ final class OptionsMiddlewareTest extends TestCase
 {
     use AssertResponseTrait;
 
-    /** @var MockObject&SwooleHttpRequest */
-    private MockObject $request;
+    private SwooleHttpRequest&MockObject $request;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandler/StaticResourceResponseTest.php
+++ b/test/StaticResourceHandler/StaticResourceResponseTest.php
@@ -85,7 +85,7 @@ final class StaticResourceResponseTest extends TestCase
         $response->setStatus(302);
         $response->addHeader('Location', 'https://example.com');
         $response->addHeader('Expires', '3600');
-        $response->setResponseContentCallback(static function (): void {
+        $response->setResponseContentCallback(static function (): never {
             TestCase::fail('Callback should not have been called');
         });
         $response->disableContent();

--- a/test/StaticResourceHandlerFactoryTest.php
+++ b/test/StaticResourceHandlerFactoryTest.php
@@ -30,8 +30,7 @@ final class StaticResourceHandlerFactoryTest extends TestCase
 {
     use AttributeAssertionTrait;
 
-    /** @psalm-var MockObject&ContainerInterface */
-    private ContainerInterface|MockObject $container;
+    private ContainerInterface&MockObject $container;
 
     protected function setUp(): void
     {

--- a/test/StaticResourceHandlerTest.php
+++ b/test/StaticResourceHandlerTest.php
@@ -22,17 +22,9 @@ final class StaticResourceHandlerTest extends TestCase
     /** @psalm-var non-empty-string */
     private string $docRoot;
 
-    /**
-     * @var SwooleHttpRequest|MockObject
-     * @psalm-var MockObject&SwooleHttpRequest
-     */
-    private $request;
+    private SwooleHttpRequest&MockObject $request;
 
-    /**
-     * @var SwooleHttpResponse|MockObject
-     * @psalm-var MockObject&SwooleHttpResponse
-     */
-    private $response;
+    private SwooleHttpResponse&MockObject $response;
 
     protected function setUp(): void
     {
@@ -82,11 +74,8 @@ final class StaticResourceHandlerTest extends TestCase
         $expectedResponse->expects($this->once())->method('sendSwooleResponse')->with($this->response, $filename);
 
         $middleware = new class ($expectedResponse) implements MiddlewareInterface {
-            private StaticResourceResponse $response;
-
-            public function __construct(StaticResourceResponse $response)
+            public function __construct(private readonly StaticResourceResponse $response)
             {
-                $this->response = $response;
             }
 
             public function __invoke(

--- a/test/SwooleEmitterTest.php
+++ b/test/SwooleEmitterTest.php
@@ -28,11 +28,7 @@ final class SwooleEmitterTest extends TestCase
 {
     private SwooleEmitter $emitter;
 
-    /**
-     * @var SwooleHttpResponse|MockObject
-     * @psalm-var MockObject&SwooleHttpResponse
-     */
-    private $swooleResponse;
+    private SwooleHttpResponse&MockObject $swooleResponse;
 
     protected function setUp(): void
     {

--- a/test/SwooleRequestHandlerRunnerTest.php
+++ b/test/SwooleRequestHandlerRunnerTest.php
@@ -35,10 +35,10 @@ use const SWOOLE_PROCESS;
 final class SwooleRequestHandlerRunnerTest extends TestCase
 {
     /** @var EventDispatcherInterface&MockObject */
-    private EventDispatcherInterface $dispatcher;
+    private MockObject $dispatcher;
 
     /** @var SwooleHttpServer&MockObject */
-    private SwooleHttpServer $httpServer;
+    private MockObject $httpServer;
 
     private SwooleRequestHandlerRunner $runner;
 
@@ -330,11 +330,8 @@ final class SwooleRequestHandlerRunnerTest extends TestCase
 
             public array $data = ['values', 'to', 'process'];
 
-            private SwooleHttpServer $server;
-
-            public function __construct(SwooleHttpServer $server)
+            public function __construct(private readonly SwooleHttpServer $server)
             {
-                $this->server = $server;
             }
 
             public function finish(string $returnValue): void

--- a/test/SwooleStreamTest.php
+++ b/test/SwooleStreamTest.php
@@ -28,8 +28,7 @@ final class SwooleStreamTest extends TestCase
      */
     public const DEFAULT_CONTENT = 'This is a test!';
 
-    /** @var SwooleHttpRequest&MockObject */
-    private MockObject $request;
+    private SwooleHttpRequest&MockObject $request;
 
     private SwooleStream $stream;
 

--- a/test/Task/TaskEventDispatchListenerTest.php
+++ b/test/Task/TaskEventDispatchListenerTest.php
@@ -23,23 +23,11 @@ use function str_contains;
 
 final class TaskEventDispatchListenerTest extends TestCase
 {
-    /**
-     * @var EventDispatcherInterface|MockObject
-     * @psalm-var EventDispatcherInterface&MockObject
-     */
-    private EventDispatcherInterface $dispatcher;
+    private EventDispatcherInterface&MockObject $dispatcher;
 
-    /**
-     * @var TaskEvent|MockObject
-     * @psalm-var TaskEvent&MockObject
-     */
-    private TaskEvent $event;
+    private TaskEvent&MockObject $event;
 
-    /**
-     * @var LoggerInterface|MockObject
-     * @psalm-var LoggerInterface&MockObject
-     */
-    private LoggerInterface $logger;
+    private LoggerInterface&MockObject $logger;
 
     protected function setUp(): void
     {

--- a/test/Task/TaskInvokerListenerTest.php
+++ b/test/Task/TaskInvokerListenerTest.php
@@ -27,23 +27,11 @@ use function str_contains;
 
 final class TaskInvokerListenerTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|MockObject
-     * @psalm-var ContainerInterface&MockObject
-     */
-    private ContainerInterface $container;
+    private ContainerInterface&MockObject $container;
 
-    /**
-     * @var TaskEvent|MockObject
-     * @psalm-var TaskEvent&MockObject
-     */
-    private TaskEvent $event;
+    private TaskEvent&MockObject $event;
 
-    /**
-     * @var LoggerInterface|MockObject
-     * @psalm-var LoggerInterface&MockObject
-     */
-    private LoggerInterface $logger;
+    private LoggerInterface&MockObject $logger;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR introduces strict typing enforcement using Rector.

- Adds Rector to the project and configures it to enforce strict typing rules.
- Applies `readonly` properties where applicable.
- Adds scalar and class **parameter types**, **return types**, and **property types** throughout the codebase.
- Updates `psalm-baseline.xml` to remove ignored issues that are now resolved through typing improvements.
