### PR TITLE
chore: add support for Symfony v8 in composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "ext-swoole": "^6.0",
         "ext-zlib": "*",
         "dflydev/fig-cookies": "^2.0.1 || ^3.0",
-        "laminas/laminas-cli": "^1.8",
         "laminas/laminas-diactoros": "^2.25.2 || ^3.0",
         "laminas/laminas-httphandlerrunner": "^2.5",
         "mezzio/mezzio": "^3.15",
@@ -49,7 +48,7 @@
         "psr/http-message-implementation": "^1.0 || ^2.0",
         "psr/http-server-handler": "^1.0.2",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^5.3 || ^6.0.19 || ^7.0",
+        "symfony/console": "^5.3 || ^6.0.19 || ^7.0 || ^8.0",
         "webmozart/assert": "^1.11 || ^2.0"
     },
     "require-dev": {
@@ -59,7 +58,7 @@
         "phpunit/phpunit": "^11.5.55",
         "psalm/plugin-phpunit": "^0.19.5",
         "swoole/ide-helper": "^6.0",
-        "vimeo/psalm": "^6.13"
+        "vimeo/psalm": "^6.14.3"
     },
     "suggest": {
         "ext-inotify": "To use inotify based file watcher. Required for hot code reloading."

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1b79f6d5bcbc018409624dda26990c9",
+    "content-hash": "b999033dbd8103ac1dc13260b6c0788e",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -123,76 +123,6 @@
                 "source": "https://github.com/php-fig/http-message-util/tree/1.1.5"
             },
             "time": "2020-11-24T22:02:12+00:00"
-        },
-        {
-            "name": "laminas/laminas-cli",
-            "version": "1.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-cli.git",
-                "reference": "926a884548a5ff078128ffa3fe9381cd0a4ae8c4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cli/zipball/926a884548a5ff078128ffa3fe9381cd0a4ae8c4",
-                "reference": "926a884548a5ff078128ffa3fe9381cd0a4ae8c4",
-                "shasum": ""
-            },
-            "require": {
-                "composer-runtime-api": "^2.0.0",
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "psr/container": "^1.0 || ^2.0",
-                "symfony/console": "^7.4 || ^8.0",
-                "symfony/event-dispatcher": "^7.4 || ^8.0",
-                "webmozart/assert": "^1.11 || ^2.1.5"
-            },
-            "conflict": {
-                "amphp/amp": "<2.6.4"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^3.1.0",
-                "laminas/laminas-mvc": "^3.8.0",
-                "laminas/laminas-servicemanager": "^3.24.0",
-                "mikey179/vfsstream": "2.0.x-dev",
-                "phpunit/phpunit": "^11.5.55",
-                "psalm/plugin-phpunit": "^0.19.5",
-                "vimeo/psalm": "^6.15.1"
-            },
-            "bin": [
-                "bin/laminas"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Cli\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Command-line interface for Laminas projects",
-            "keywords": [
-                "cli",
-                "command",
-                "console",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-cli/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/mezzio/laminas-cli/issues",
-                "rss": "https://github.com/mezzio/laminas-cli/releases.atom",
-                "source": "https://github.com/mezzio/laminas-cli"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2026-03-10T09:04:36+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -1261,167 +1191,6 @@
             "homepage": "https://symfony.com",
             "support": {
                 "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v7.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f57b899fa736fd71121168ef268f23c206083f0a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f57b899fa736fd71121168ef268f23c206083f0a",
-                "reference": "f57b899fa736fd71121168ef268f23c206083f0a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/event-dispatcher-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/service-contracts": "<2.5"
-            },
-            "provide": {
-                "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "2.0|3.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-30T13:54:39+00:00"
-        },
-        {
-            "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/event-dispatcher": "^1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\EventDispatcher\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to dispatching event",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -6774,5 +6543,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -20,17 +20,7 @@
       <code><![CDATA[$defaultName]]></code>
     </PossiblyUnusedProperty>
   </file>
-  <file src="src/Command/StartCommand.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$defaultName]]></code>
-    </PossiblyUnusedProperty>
-  </file>
   <file src="src/Command/StatusCommand.php">
-    <PossiblyUnusedProperty>
-      <code><![CDATA[$defaultName]]></code>
-    </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Command/StopCommand.php">
     <PossiblyUnusedProperty>
       <code><![CDATA[$defaultName]]></code>
     </PossiblyUnusedProperty>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,10 +16,6 @@
     </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/Command/ReloadCommand.php">
-    <DeprecatedMethod>
-      <code><![CDATA[StartCommand::getDefaultName()]]></code>
-      <code><![CDATA[StopCommand::getDefaultName()]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedProperty>
       <code><![CDATA[$defaultName]]></code>
     </PossiblyUnusedProperty>
@@ -366,15 +362,6 @@
       <code><![CDATA[$ignoreCase]]></code>
       <code><![CDATA[$maxDepth]]></code>
     </PossiblyUnusedParam>
-  </file>
-  <file src="test/Command/ReloadCommandTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[StartCommand::getDefaultName()]]></code>
-      <code><![CDATA[StartCommand::getDefaultName()]]></code>
-      <code><![CDATA[StopCommand::getDefaultName()]]></code>
-      <code><![CDATA[StopCommand::getDefaultName()]]></code>
-      <code><![CDATA[StopCommand::getDefaultName()]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="test/Command/StartCommandTest.php">
     <PossiblyFalseArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -20,7 +20,17 @@
       <code><![CDATA[$defaultName]]></code>
     </PossiblyUnusedProperty>
   </file>
+  <file src="src/Command/StartCommand.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$defaultName]]></code>
+    </PossiblyUnusedProperty>
+  </file>
   <file src="src/Command/StatusCommand.php">
+    <PossiblyUnusedProperty>
+      <code><![CDATA[$defaultName]]></code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/Command/StopCommand.php">
     <PossiblyUnusedProperty>
       <code><![CDATA[$defaultName]]></code>
     </PossiblyUnusedProperty>

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -36,7 +36,7 @@ configuration value is set to SWOOLE_PROCESS.
 EOH;
 
     /**
-     * @deprecated Use ReloadCommand::getDefaultName() instead. Will be removed in 5.0.0
+     * @deprecated Use the #[AsCommand] attribute to retrieve the command name. Will be removed in 5.0.0.
      *
      * @var null|string
      */
@@ -81,7 +81,7 @@ EOH;
 
         $stop   = $application->find('mezzio:swoole:stop');
         $result = $stop->run(new ArrayInput([
-            'command' => 'stop',
+            'command' => 'mezzio:swoole:stop',
         ]), $output);
 
         if (0 !== $result) {
@@ -101,7 +101,7 @@ EOH;
         $start = $application->find('mezzio:swoole:start');
 
         $inputArguments = [
-            'command'       => 'start',
+            'command'       => 'mezzio:swoole:start',
             '--daemonize'   => true,
             '--num-workers' => $input->getOption('num-workers') ?? StartCommand::DEFAULT_NUM_WORKERS,
         ];

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -20,11 +20,9 @@ use function sleep;
 
 use const SWOOLE_PROCESS;
 
-#[AsCommand(self::COMMAND_NAME)]
+#[AsCommand('mezzio:swoole:reload')]
 class ReloadCommand extends Command
 {
-    public const COMMAND_NAME = 'mezzio:swoole:reload';
-
     /**
      * @var string
      */
@@ -42,7 +40,7 @@ EOH;
      *
      * @var null|string
      */
-    public static $defaultName = self::COMMAND_NAME;
+    public static $defaultName = 'mezzio:swoole:reload';
 
     public function __construct(private int $serverMode)
     {
@@ -81,7 +79,7 @@ EOH;
         /** @var Application $application */
         $application = $this->getApplication();
 
-        $stop   = $application->find(StopCommand::COMMAND_NAME);
+        $stop   = $application->get(StopCommand::class);
         $result = $stop->run(new ArrayInput([
             'command' => 'stop',
         ]), $output);
@@ -100,7 +98,7 @@ EOH;
         $output->writeln('<info>[DONE]</info>');
         $output->writeln('<info>Starting server</info>');
 
-        $start = $application->find(StartCommand::COMMAND_NAME);
+        $start = $application->get(StartCommand::class);
 
         $inputArguments = [
             'command'       => 'start',

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -79,7 +79,7 @@ EOH;
         /** @var Application $application */
         $application = $this->getApplication();
 
-        $stop   = $application->get(StopCommand::class);
+        $stop   = $application->find('mezzio:swoole:stop');
         $result = $stop->run(new ArrayInput([
             'command' => 'stop',
         ]), $output);
@@ -98,7 +98,7 @@ EOH;
         $output->writeln('<info>[DONE]</info>');
         $output->writeln('<info>Starting server</info>');
 
-        $start = $application->get(StartCommand::class);
+        $start = $application->find('mezzio:swoole:start');
 
         $inputArguments = [
             'command'       => 'start',

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -20,9 +20,11 @@ use function sleep;
 
 use const SWOOLE_PROCESS;
 
-#[AsCommand('mezzio:swoole:reload')]
+#[AsCommand(self::COMMAND_NAME)]
 class ReloadCommand extends Command
 {
+    public const COMMAND_NAME = 'mezzio:swoole:reload';
+
     /**
      * @var string
      */
@@ -40,7 +42,7 @@ EOH;
      *
      * @var null|string
      */
-    public static $defaultName = 'mezzio:swoole:reload';
+    public static $defaultName = self::COMMAND_NAME;
 
     public function __construct(private int $serverMode)
     {
@@ -79,7 +81,7 @@ EOH;
         /** @var Application $application */
         $application = $this->getApplication();
 
-        $stop   = $application->find(StopCommand::getDefaultName());
+        $stop   = $application->find(StopCommand::COMMAND_NAME);
         $result = $stop->run(new ArrayInput([
             'command' => 'stop',
         ]), $output);
@@ -98,7 +100,7 @@ EOH;
         $output->writeln('<info>[DONE]</info>');
         $output->writeln('<info>Starting server</info>');
 
-        $start = $application->find(StartCommand::getDefaultName());
+        $start = $application->find(StartCommand::COMMAND_NAME);
 
         $inputArguments = [
             'command'       => 'start',

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function file_exists;
 
-#[AsCommand(self::COMMAND_NAME)]
+#[AsCommand('mezzio:swoole:start')]
 class StartCommand extends Command
 {
     use IsRunningTrait;
@@ -32,8 +32,6 @@ class StartCommand extends Command
      * @var int
      */
     public const DEFAULT_NUM_WORKERS = 4;
-
-    public const COMMAND_NAME = 'mezzio:swoole:start';
 
     /**
      * @var string
@@ -54,13 +52,6 @@ EOH;
         'config/pipeline.php',
         'config/routes.php',
     ];
-
-    /**
-     * @deprecated Use StartCommand::getDefaultName() instead. Will be removed in 5.0.0
-     *
-     * @var null|string
-     */
-    public static $defaultName = self::COMMAND_NAME;
 
     public function __construct(private ContainerInterface $container)
     {

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function file_exists;
 
-#[AsCommand('mezzio:swoole:start')]
+#[AsCommand(self::COMMAND_NAME)]
 class StartCommand extends Command
 {
     use IsRunningTrait;
@@ -32,6 +32,8 @@ class StartCommand extends Command
      * @var int
      */
     public const DEFAULT_NUM_WORKERS = 4;
+
+    public const COMMAND_NAME = 'mezzio:swoole:start';
 
     /**
      * @var string
@@ -58,7 +60,7 @@ EOH;
      *
      * @var null|string
      */
-    public static $defaultName = 'mezzio:swoole:start';
+    public static $defaultName = self::COMMAND_NAME;
 
     public function __construct(private ContainerInterface $container)
     {

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -46,6 +46,13 @@ do not provide the option, 4 workers will be started.
 EOH;
 
     /**
+     * @deprecated Use the #[AsCommand] attribute to retrieve the command name. Will be removed in 5.0.0.
+     *
+     * @var null|string
+     */
+    public static $defaultName = 'mezzio:swoole:start';
+
+    /**
      * @var string[]
      */
     private const PROGRAMMATIC_CONFIG_FILES = [

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -30,7 +30,7 @@ This command is only relevant when the server was started using the
 EOH;
 
     /**
-     * @deprecated Use StatusCommand::getDefaultName() instead. Will be removed in 5.0.0
+     * @deprecated Use the #[AsCommand] attribute to retrieve the command name. Will be removed in 5.0.0.
      *
      * @var null|string
      */

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -19,12 +19,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function time;
 use function usleep;
 
-#[AsCommand(self::COMMAND_NAME)]
+#[AsCommand('mezzio:swoole:stop')]
 class StopCommand extends Command
 {
     use IsRunningTrait;
-
-    public const COMMAND_NAME = 'mezzio:swoole:stop';
 
     /**
      * @var string
@@ -35,13 +33,6 @@ Stop the web server. Kills all worker processes and stops the web server.
 This command is only relevant when the server was started using the
 --daemonize option.
 EOH;
-
-    /**
-     * @deprecated Use StopCommand::getDefaultName() instead. Will be removed in 5.0.0
-     *
-     * @var null|string
-     */
-    public static $defaultName = self::COMMAND_NAME;
 
     /**
      * @internal

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -35,6 +35,13 @@ This command is only relevant when the server was started using the
 EOH;
 
     /**
+     * @deprecated Use the #[AsCommand] attribute to retrieve the command name. Will be removed in 5.0.0.
+     *
+     * @var null|string
+     */
+    public static $defaultName = 'mezzio:swoole:stop';
+
+    /**
      * @internal
      *
      * @var Closure Callable to execute when attempting to kill the server

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -19,10 +19,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function time;
 use function usleep;
 
-#[AsCommand('mezzio:swoole:stop')]
+#[AsCommand(self::COMMAND_NAME)]
 class StopCommand extends Command
 {
     use IsRunningTrait;
+
+    public const COMMAND_NAME = 'mezzio:swoole:stop';
 
     /**
      * @var string
@@ -39,7 +41,7 @@ EOH;
      *
      * @var null|string
      */
-    public static $defaultName = 'mezzio:swoole:stop';
+    public static $defaultName = self::COMMAND_NAME;
 
     /**
      * @internal

--- a/test/Command/CommandNameTrait.php
+++ b/test/Command/CommandNameTrait.php
@@ -7,13 +7,17 @@ namespace MezzioTest\Swoole\Command;
 use ReflectionClass;
 use Symfony\Component\Console\Attribute\AsCommand;
 
+use function assert;
+use function class_exists;
+
 trait CommandNameTrait
 {
     /**
      * @param class-string $commandClass
      */
-    public function commandName(string $commandClass): ?string
+    public static function commandName(string $commandClass): ?string
     {
+        assert(class_exists($commandClass));
         if ($attribute = (new ReflectionClass($commandClass))->getAttributes(AsCommand::class)) {
             return $attribute[0]->newInstance()->name;
         }

--- a/test/Command/CommandNameTrait.php
+++ b/test/Command/CommandNameTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Swoole\Command;
+
+use ReflectionClass;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+trait CommandNameTrait
+{
+    /**
+     * @param class-string $commandClass
+     */
+    public function commandName(string $commandClass): ?string
+    {
+        if ($attribute = (new ReflectionClass($commandClass))->getAttributes(AsCommand::class)) {
+            return $attribute[0]->newInstance()->name;
+        }
+
+        return null;
+    }
+}

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -29,6 +29,7 @@ use const SWOOLE_PROCESS;
 final class ReloadCommandTest extends TestCase
 {
     use AttributeAssertionTrait;
+    use CommandNameTrait;
     use ReflectMethodTrait;
 
     /** @psalm-var MockObject&InputInterface */
@@ -149,7 +150,7 @@ final class ReloadCommandTest extends TestCase
             ->willReturn(1);
 
         $application = $this->mockApplication();
-        $application->method('get')->with(StopCommand::class)->willReturn($stopCommand);
+        $application->method('find')->with($this->commandName(StopCommand::class))->willReturn($stopCommand);
 
         $command->setApplication($application);
 
@@ -198,10 +199,10 @@ final class ReloadCommandTest extends TestCase
         $application = $this->mockApplication();
         $application
             ->expects($this->exactly(2))
-            ->method('get')
+            ->method('find')
             ->willReturnMap([
-                [StopCommand::class, $stopCommand],
-                [StartCommand::class, $startCommand],
+                [$this->commandName(StopCommand::class), $stopCommand],
+                [$this->commandName(StartCommand::class), $startCommand],
             ]);
 
         $command->setApplication($application);
@@ -268,10 +269,10 @@ final class ReloadCommandTest extends TestCase
         $application = $this->mockApplication();
         $application
             ->expects($this->exactly(2))
-            ->method('get')
+            ->method('find')
             ->willReturnMap([
-                [StopCommand::class, $stopCommand],
-                [StartCommand::class, $startCommand],
+                [$this->commandName(StopCommand::class), $stopCommand],
+                [$this->commandName(StartCommand::class), $startCommand],
             ]);
 
         $this->output

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -144,13 +144,13 @@ final class ReloadCommandTest extends TestCase
         $stopCommand
             ->method('run')
             ->with(
-                $this->callback(static fn(ArrayInput $arg) => 'stop' === (string) $arg),
+                $this->callback(static fn(ArrayInput $arg) => "'mezzio:swoole:stop'" === (string) $arg),
                 $this->output
             )
             ->willReturn(1);
 
         $application = $this->mockApplication();
-        $application->method('find')->with($this->commandName(StopCommand::class))->willReturn($stopCommand);
+        $application->method('find')->with(self::commandName(StopCommand::class))->willReturn($stopCommand);
 
         $command->setApplication($application);
 
@@ -182,7 +182,7 @@ final class ReloadCommandTest extends TestCase
         $stopCommand
             ->method('run')
             ->with(
-                $this->callback(static fn(ArrayInput $arg) => 'stop' === (string) $arg),
+                $this->callback(static fn(ArrayInput $arg) => "'mezzio:swoole:stop'" === (string) $arg),
                 $this->output
             )
             ->willReturn(0);
@@ -191,7 +191,10 @@ final class ReloadCommandTest extends TestCase
         $startCommand
             ->method('run')
             ->with(
-                $this->callback(static fn(ArrayInput $arg) => 'start --daemonize=1 --num-workers=5' === (string) $arg),
+                $this->callback(
+                    static fn(ArrayInput $arg)
+                        => "'mezzio:swoole:start' --daemonize=1 --num-workers=5" === (string) $arg
+                ),
                 $this->output
             )
             ->willReturn(1);
@@ -201,8 +204,8 @@ final class ReloadCommandTest extends TestCase
             ->expects($this->exactly(2))
             ->method('find')
             ->willReturnMap([
-                [$this->commandName(StopCommand::class), $stopCommand],
-                [$this->commandName(StartCommand::class), $startCommand],
+                [self::commandName(StopCommand::class), $stopCommand],
+                [self::commandName(StartCommand::class), $startCommand],
             ]);
 
         $command->setApplication($application);
@@ -249,7 +252,7 @@ final class ReloadCommandTest extends TestCase
         $stopCommand
             ->method('run')
             ->with(
-                $this->callback(static fn(ArrayInput $arg) => 'stop' === (string) $arg),
+                $this->callback(static fn(ArrayInput $arg) => "'mezzio:swoole:stop'" === (string) $arg),
                 $this->output
             )
             ->willReturn(0);
@@ -260,7 +263,7 @@ final class ReloadCommandTest extends TestCase
             ->with(
                 $this->callback(
                     static fn(ArrayInput $arg)
-                        => 'start --daemonize=1 --num-workers=5 --num-task-workers=2' === (string) $arg
+                        => "'mezzio:swoole:start' --daemonize=1 --num-workers=5 --num-task-workers=2" === (string) $arg
                 ),
                 $this->output
             )
@@ -271,8 +274,8 @@ final class ReloadCommandTest extends TestCase
             ->expects($this->exactly(2))
             ->method('find')
             ->willReturnMap([
-                [$this->commandName(StopCommand::class), $stopCommand],
-                [$this->commandName(StartCommand::class), $startCommand],
+                [self::commandName(StopCommand::class), $stopCommand],
+                [self::commandName(StartCommand::class), $startCommand],
             ]);
 
         $this->output

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -149,7 +149,7 @@ final class ReloadCommandTest extends TestCase
             ->willReturn(1);
 
         $application = $this->mockApplication();
-        $application->method('find')->with(StopCommand::COMMAND_NAME)->willReturn($stopCommand);
+        $application->method('get')->with(StopCommand::class)->willReturn($stopCommand);
 
         $command->setApplication($application);
 
@@ -198,10 +198,10 @@ final class ReloadCommandTest extends TestCase
         $application = $this->mockApplication();
         $application
             ->expects($this->exactly(2))
-            ->method('find')
+            ->method('get')
             ->willReturnMap([
-                [StopCommand::COMMAND_NAME, $stopCommand],
-                [StartCommand::COMMAND_NAME, $startCommand],
+                [StopCommand::class, $stopCommand],
+                [StartCommand::class, $startCommand],
             ]);
 
         $command->setApplication($application);
@@ -268,10 +268,10 @@ final class ReloadCommandTest extends TestCase
         $application = $this->mockApplication();
         $application
             ->expects($this->exactly(2))
-            ->method('find')
+            ->method('get')
             ->willReturnMap([
-                [StopCommand::COMMAND_NAME, $stopCommand],
-                [StartCommand::COMMAND_NAME, $startCommand],
+                [StopCommand::class, $stopCommand],
+                [StartCommand::class, $startCommand],
             ]);
 
         $this->output

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -149,7 +149,7 @@ final class ReloadCommandTest extends TestCase
             ->willReturn(1);
 
         $application = $this->mockApplication();
-        $application->method('find')->with(StopCommand::getDefaultName())->willReturn($stopCommand);
+        $application->method('find')->with(StopCommand::COMMAND_NAME)->willReturn($stopCommand);
 
         $command->setApplication($application);
 
@@ -200,8 +200,8 @@ final class ReloadCommandTest extends TestCase
             ->expects($this->exactly(2))
             ->method('find')
             ->willReturnMap([
-                [StopCommand::getDefaultName(), $stopCommand],
-                [StartCommand::getDefaultName(), $startCommand],
+                [StopCommand::COMMAND_NAME, $stopCommand],
+                [StartCommand::COMMAND_NAME, $startCommand],
             ]);
 
         $command->setApplication($application);
@@ -270,8 +270,8 @@ final class ReloadCommandTest extends TestCase
             ->expects($this->exactly(2))
             ->method('find')
             ->willReturnMap([
-                [StopCommand::getDefaultName(), $stopCommand],
-                [StartCommand::getDefaultName(), $startCommand],
+                [StopCommand::COMMAND_NAME, $stopCommand],
+                [StartCommand::COMMAND_NAME, $startCommand],
             ]);
 
         $this->output


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR updates the Symfony Console dependency.

It is based on the renvoate prev attempt:
https://github.com/mezzio/mezzio-swoole/pull/149

The original PR failed CI at the time, but the checks now pass with the current
dependency versions.