### PR TITLE
refactor: rename FirstClassCallableRector to ArrayToFirstClassCallabl…

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php81\Rector\Array_\FirstClassCallableRector;
+use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
 
 return RectorConfig::configure()
@@ -21,7 +21,7 @@ return RectorConfig::configure()
         // vs
         // $this->httpServer->on('managerstart', $this->onManagerStart(...)
         // is not the same
-        FirstClassCallableRector::class => [
+        ArrayToFirstClassCallableRector::class => [
             __DIR__ . '/src/SwooleRequestHandlerRunner.php',
             __DIR__ . '/test/SwooleRequestHandlerRunnerTest.php',
             __DIR__ . '/test/Task/TaskTest.php',

--- a/src/StaticResourceHandler/ETagMiddleware.php
+++ b/src/StaticResourceHandler/ETagMiddleware.php
@@ -20,6 +20,7 @@ use function in_array;
 use function md5_file;
 use function preg_match;
 use function sprintf;
+use function trim;
 
 class ETagMiddleware implements MiddlewareInterface
 {
@@ -125,7 +126,7 @@ class ETagMiddleware implements MiddlewareInterface
         $ifMatch     = $request->header['if-match'] ?? '';
         $ifNoneMatch = $request->header['if-none-match'] ?? '';
         $clientEtags = explode(',', $ifMatch !== '' ? $ifMatch : $ifNoneMatch);
-        array_walk($clientEtags, 'trim');
+        array_walk($clientEtags, trim(...));
 
         if (in_array($etag, $clientEtags, true)) {
             $response->setStatus(304);


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR updates Rector configuration to make the codebase compatible with the latest Rector rules.

Specifically:
- replaces `FirstClassCallableRector::class` with `ArrayToFirstClassCallableRector::class`
- applies Rector fixes accordingly

This change is purely a QA improvement to satisfy Rector and does not introduce any functional changes.

No behavior is changed